### PR TITLE
Feat: receiver_iva_condition

### DIFF
--- a/lib/snoopy_afip/authorize_adapter.rb
+++ b/lib/snoopy_afip/authorize_adapter.rb
@@ -62,14 +62,15 @@ module Snoopy
       # today = Time.new.in_time_zone('Buenos Aires').strftime('%Y%m%d')
       today = Date.today.strftime('%Y%m%d')
       fecaereq = {"FeCAEReq" => { "FeCabReq" => { "CantReg" => "1", "CbteTipo" => bill.cbte_type, "PtoVta" => bill.sale_point },
-                                  "FeDetReq" => { "FECAEDetRequest" => { "Concepto"   => Snoopy::CONCEPTS[bill.concept],
-                                                                         "DocTipo"    => Snoopy::DOCUMENTS[bill.document_type],
-                                                                         "CbteFch"    => today,
-                                                                         "ImpTotConc" => 0.00,
-                                                                         "MonId"      => Snoopy::CURRENCY[bill.currency][:code],
-                                                                         "MonCotiz"   => bill.exchange_rate,
-                                                                         "ImpOpEx"    => 0.00,
-                                                                         "ImpTrib"    => 0.00 }}}}
+                                  "FeDetReq" => { "FECAEDetRequest" => { "Concepto"               => Snoopy::CONCEPTS[bill.concept],
+                                                                         "DocTipo"                => Snoopy::DOCUMENTS[bill.document_type],
+                                                                         "CbteFch"                => today,
+                                                                         "ImpTotConc"             => 0.00,
+                                                                         "MonId"                  => Snoopy::CURRENCY[bill.currency][:code],
+                                                                         "MonCotiz"               => bill.exchange_rate,
+                                                                         "ImpOpEx"                => 0.00,
+                                                                         "ImpTrib"                => 0.00,
+                                                                         "CondicionIVAReceptorId" => bill.receiver_iva_condition_id }}}}
 
       unless bill.issuer_iva_cond.to_sym == Snoopy::RESPONSABLE_MONOTRIBUTO
         _alicivas = bill.alicivas.collect do |aliciva|

--- a/lib/snoopy_afip/bill.rb
+++ b/lib/snoopy_afip/bill.rb
@@ -9,8 +9,7 @@ module Snoopy
 
     TAX_ATTRIBUTES = [:id, :amount, :taxeable_base]
 
-    ATTRIBUTES_PRECENSE = [:total_net, :concept, :receiver_iva_cond, :alicivas, :document_type, :service_date_from, :service_date_to, :sale_point, :issuer_iva_cond]
-    # ATTRIBUTES_PRECENSE = [:total_net, :concept, :receiver_iva_cond, :alicivas, :document_type, :service_date_from, :service_date_to, :sale_point, :issuer_iva_cond, :receiver_iva_condition]
+    ATTRIBUTES_PRECENSE = [:total_net, :concept, :receiver_iva_cond, :alicivas, :document_type, :service_date_from, :service_date_to, :sale_point, :issuer_iva_cond, :receiver_iva_condition]
 
     attr_accessor *ATTRIBUTES
 
@@ -108,7 +107,9 @@ module Snoopy
     alias :to_hash :to_h
 
     def receiver_iva_condition_id
-      Snoopy::IVA_COND_RECEIVER[@receiver_iva_condition.to_sym]# || '5'
+      return '' if @receiver_iva_condition.nil?
+
+      Snoopy::IVA_COND_RECEIVER[@receiver_iva_condition.to_sym]
     end
 
     private
@@ -153,7 +154,7 @@ module Snoopy
         status = false unless errors.empty?
       end
 
-      unless Snoopy::IVA_COND_RECEIVER.keys.include?(@receiver_iva_condition.to_sym)
+      unless Snoopy::IVA_COND_RECEIVER.keys.include?(@receiver_iva_condition&.to_sym)
         @errors[:receiver_iva_condition] = [] unless errors.has_key?(:receiver_iva_condition)
         @errors[:receiver_iva_condition] << Snoopy::Exception::Bill::InvalidValueAttribute.new("Invalid value #{@receiver_iva_condition}. Possible values #{Snoopy::IVA_COND_RECEIVER.keys}").message
         status = false unless errors.empty?

--- a/lib/snoopy_afip/bill.rb
+++ b/lib/snoopy_afip/bill.rb
@@ -5,11 +5,12 @@ module Snoopy
                   :cbte_asoc_num, :cae, :service_date_to, :due_date,
                   :number, :alicivas, :cuit, :sale_point, :service_date_from,
                   :due_date_cae, :voucher_date, :process_date, :imp_iva, :cbte_asoc_to_sale_point,
-                  :receiver_iva_cond, :issuer_iva_cond, :errors, :asoc_receiver_iva_cond]
+                  :receiver_iva_cond, :issuer_iva_cond, :errors, :asoc_receiver_iva_cond, :receiver_iva_condition]
 
     TAX_ATTRIBUTES = [:id, :amount, :taxeable_base]
 
     ATTRIBUTES_PRECENSE = [:total_net, :concept, :receiver_iva_cond, :alicivas, :document_type, :service_date_from, :service_date_to, :sale_point, :issuer_iva_cond]
+    # ATTRIBUTES_PRECENSE = [:total_net, :concept, :receiver_iva_cond, :alicivas, :document_type, :service_date_from, :service_date_to, :sale_point, :issuer_iva_cond, :receiver_iva_condition]
 
     attr_accessor *ATTRIBUTES
 
@@ -31,9 +32,10 @@ module Snoopy
       @issuer_iva_cond         = attrs[:issuer_iva_cond]
       @service_date_to         = attrs[:service_date_to]
       @service_date_from       = attrs[:service_date_from]
-      @receiver_iva_cond       = attrs[:receiver_iva_cond]
+      @receiver_iva_cond       = attrs[:receiver_iva_cond] # Esto se usa para el cbte_type
       @asoc_receiver_iva_cond  = attrs[:asoc_receiver_iva_cond]
       @cbte_asoc_to_sale_point = attrs[:cbte_asoc_to_sale_point] # Esto es el punto de venta de la factura para la nota de credito
+      @receiver_iva_condition  = attrs[:receiver_iva_condition] # La verdadera condicion de iva del receptor
     end
 
     # def self.bill_request(number, attrs={})
@@ -105,6 +107,10 @@ module Snoopy
     end
     alias :to_hash :to_h
 
+    def receiver_iva_condition_id
+      Snoopy::IVA_COND_RECEIVER[@receiver_iva_condition.to_sym]# || '5'
+    end
+
     private
 
     def validate!
@@ -144,6 +150,12 @@ module Snoopy
       unless Snoopy::BILL_TYPE.keys.include?(@receiver_iva_cond.to_sym)
         @errors[:receiver_iva_cond] = [] unless errors.has_key?(:receiver_iva_cond)
         @errors[:receiver_iva_cond] << Snoopy::Exception::Bill::InvalidValueAttribute.new("Invalid value #{@receiver_iva_cond}. Possible values #{Snoopy::BILL_TYPE.keys}").message
+        status = false unless errors.empty?
+      end
+
+      unless Snoopy::IVA_COND_RECEIVER.keys.include?(@receiver_iva_condition.to_sym)
+        @errors[:receiver_iva_condition] = [] unless errors.has_key?(:receiver_iva_condition)
+        @errors[:receiver_iva_condition] << Snoopy::Exception::Bill::InvalidValueAttribute.new("Invalid value #{@receiver_iva_condition}. Possible values #{Snoopy::IVA_COND_RECEIVER.keys}").message
         status = false unless errors.empty?
       end
 

--- a/lib/snoopy_afip/constants.rb
+++ b/lib/snoopy_afip/constants.rb
@@ -25,8 +25,21 @@ module Snoopy
 
   RESPONSABLE_INSCRIPTO   = :responsable_inscripto
   RESPONSABLE_MONOTRIBUTO = :responsable_monotributo
+  CONSUMIDOR_FINAL        = :consumidor_final
+  IVA_SUJETO_EXENTO       = :sujeto_exento
+  IVA_NO_ALCANZADO        = :no_alcanzado
 
+  # Issuer
   IVA_COND = [ RESPONSABLE_MONOTRIBUTO, RESPONSABLE_INSCRIPTO ]
+
+  # Receiver
+  IVA_COND_RECEIVER = {
+    RESPONSABLE_INSCRIPTO   => '1', # registered_vat_payer
+    RESPONSABLE_MONOTRIBUTO => '6', # self_employed_taxpayer
+    CONSUMIDOR_FINAL        => '5', # final_consumer
+    IVA_SUJETO_EXENTO       => '4', # exempt
+    IVA_NO_ALCANZADO        => '15' # not_applicable
+  }.freeze
 
   CONCEPTS = { 'Productos'             => '01',
                'Servicios'             => '02',

--- a/lib/snoopy_afip/version.rb
+++ b/lib/snoopy_afip/version.rb
@@ -1,3 +1,3 @@
 module Snoopy
-  VERSION = "4.2.2"
+  VERSION = "4.3.0"
 end


### PR DESCRIPTION
- Se agrega el "CondicionIVAReceptorId" en el método build_body_request usado en el método :fecae_solicitar
- Se agregan constantes, especialmente el IVA_COND_RECEIVER para los códigos a enviar como CondicionIVAReceptorId