### PR TITLE
docs: regenerar grafo de arquitectura completo + normalización skills/agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,3 +71,26 @@ Derivada de `lib/` (módulo `Snoopy`, autoloads en `lib/snoopy_afip.rb`):
 - **`lib/snoopy_afip/core_ext/`**: extensiones a `String`, `Hash` y `Float`.
 
 El acoplamiento de las capas de parseo es deliberado (ver README §"No Explota"): un cambio de formato de AFIP en una capa no debe tumbar el parseo de las demás.
+
+## Mapa de conocimiento (cómo leer la doc de este repo)
+
+- **Tu conocimiento = la UNIÓN de este repo + sus asociados.** No termina en el `docs/<capa>/` local: incluye la doc de los servicios/gemas de `skills.yml`. Un flujo o pregunta que cruza repos no vive como doc estática en ninguno — se compone on-demand recorriendo el grafo: seguí las anclas (`docs/consumed/`, `**Canónico:**`) hasta los repos asociados y unificá.
+- **Entrá por** [`skill/SKILL.md`](skill/SKILL.md) — índice de agente; resume el contrato y linkea el detalle.
+- **Detalle por capa** (`docs/<capa>/`), cobertura declarada:
+
+  | capa | estado |
+  |---|---|
+  | `docs/interface/` (RFC-004) | presente |
+  | `docs/topology/` (RFC-006) | presente |
+  | `docs/consumed/` (RFC-018) | presente — AFIP WSAA + WSFE |
+  | `docs/errors/` (RFC-020) | presente |
+  | `docs/config/` (RFC-012) | presente |
+  | `docs/test/` (RFC-013) | presente |
+  | `docs/glossary/` (RFC-009) | presente |
+  | `docs/behavior/` (RFC-007) | presente |
+  | `docs/api/` (RFC-003) | **n/a** — gema SOAP, sin superficie HTTP/CLI/eventos propia |
+  | `docs/data/` (RFC-002) | **n/a** — sin base de datos |
+  | `docs/events/` (RFC-005) · multi-tenancy (RFC-023) | **n/a** — sin pub/sub ni tenant |
+
+- **Qué consumimos:** [`docs/consumed/afip.md`](docs/consumed/afip.md) (RFC-018) — servicios SOAP externos de AFIP.
+- **Navegar una ancla cross-repo:** tomá la key de servicio en `skills.yml` (`services.<dep>.repo`) → ese repo es un checkout hermano local o alcanzable por GitHub MCP. La doc de los asociados ES parte de tu conocimiento accesible. (Hoy las dependencias de esta gema son externas a AFIP, no del fleet.)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,73 @@
+# AGENTS.md — snoopy_afip
+
+Fuente de verdad para reglas, convenciones, estructura, documentación, entorno y arquitectura de esta gema. Leer antes de hacer cambios.
+
+## 1. Identidad
+
+`snoopy_afip` es una gema Ruby que adapta la **Facturación Electrónica de AFIP (Argentina)**. Expone el módulo `Snoopy`.
+
+Resuelve dos servicios SOAP de AFIP (vía `savon`):
+
+- **WSAA** (autenticación): obtiene `token`, `sign` y `expiration_time` a partir de una clave privada y un certificado. Implementado en `Snoopy::AuthenticationAdapter`.
+- **WSFE** (autorización de comprobantes electrónicos): autoriza facturas/notas de crédito contra el web service. Implementado en `Snoopy::AuthorizeAdapter`, operando sobre objetos `Snoopy::Bill`.
+
+Verificado en: `snoopy_afip.gemspec` (`summary = "Adaptador AFIP wsfe."`, `description = "Adaptador para Web Service de Facturación Electrónica Argentina (AFIP)"`), `README.md` y `lib/`.
+
+## 2. Convenciones del framework
+
+El repo consume skills del framework de agentes, declaradas en `skills.yml`. Las skills se sincronizan en `.agents/skills/` y traen conocimiento específico de cada herramienta o dependencia.
+
+- Antes de responder o actuar sobre un tema cubierto por una skill, leer la skill correspondiente en `.agents/skills/`.
+- Skills declaradas hoy (`skills.yml`): `multi-vendor-feedback`, `yard`, `quality-code`, `gem-release`, `arch-structure`, `arch-compose`, `arch-enrich`, `skill-feedback`, `agent-issue`, `bug-report`, `dev-flow`, `documentation-writer`, `matrix-element`.
+- MCPs declarados: `github`, `clickup`.
+
+## 3. Entorno
+
+- Lenguaje: **Ruby**. No hay `.ruby-version` en el repo (no fijar una versión que no esté declarada).
+- Dependencias resueltas en `Gemfile.lock`. Dependencia de runtime principal: `savon ~> 2.12.1` (cliente SOAP), declarada en el `.gemspec`.
+- Gestión de versiones de Ruby con **chruby** (no rvm, no rbenv).
+- **Bundler** para dependencias (`BUNDLED WITH 2.1.4` en `Gemfile.lock`). Instalar con `bundle install`.
+
+## 4. RuboCop
+
+Esta gema **no** tiene `.rubocop.yml` configurado actualmente. La skill `quality-code` está declarada en `skills.yml` para calidad de código. Aplicar las reglas de calidad solo si se incorpora una configuración de RuboCop al repo; en ese caso, correr `bundle exec rubocop -a` antes de commitear.
+
+## 5. YARD
+
+Documentación incremental con la skill `yard`. Medir cobertura de doc con:
+
+```bash
+bundle exec yard stats --list-undoc
+```
+
+Documentar el código nuevo o modificado.
+
+## 6. Testing
+
+Framework: **RSpec** (verificado en `spec/spec_helper.rb` con `require 'rspec'` y specs `describe`/`it` en `spec/snoopy_afip/`). Correr la suite con:
+
+```bash
+bundle exec rspec
+```
+
+El código nuevo debe venir con tests. Specs actuales: `spec/snoopy_afip/bill_spec.rb`, `spec/snoopy_afip/authorizer_spec.rb`. `spec/spec_helper.rb` requiere una variable de entorno `CUIT` (usar valores de prueba, nunca CUIT/credenciales reales).
+
+## 7. Releases
+
+Usar la skill `/gem-release` (declarada en `skills.yml`) para publicar versiones. La versión vive en `lib/snoopy_afip/version.rb` (`Snoopy::VERSION`).
+
+No hay GitHub Action de release en el repo (no existe `.github/workflows/`). No documentar un pipeline automático que no esté presente.
+
+## 8. Arquitectura
+
+Derivada de `lib/` (módulo `Snoopy`, autoloads en `lib/snoopy_afip.rb`):
+
+- **`Snoopy`** (`lib/snoopy_afip.rb`): módulo de configuración global vía `attr_accessor` (`cuit`, `sale_point`, `service_url`, `auth_url`, `pkey`, `cert`, `default_document_type`, `default_concept`, `default_currency`, `own_iva_cond`, `open_timeout`, `read_timeout`, `verbose`). `open_timeout`/`read_timeout` por defecto en 30. Expone helpers `auth_hash` y `bill_types`.
+- **`Snoopy::Client`** (`client.rb`): envoltorio fino sobre `Savon.client`; `#call` aplica `Timeout` y traduce fallos a `Snoopy::Exception::ServerTimeout` / `Snoopy::Exception::ClientError`.
+- **`Snoopy::AuthenticationAdapter`** (`authentication_adapter.rb`): flujo WSAA — genera TRA/CMS y obtiene `token`/`sign`/`expiration_time`. También métodos de generación de clave privada y de solicitud de certificado (`generate_pkey`, `generate_certificate_request_with_ruby`, `..._with_bash`).
+- **`Snoopy::AuthorizeAdapter`** (`authorize_adapter.rb`): flujo WSFE — toma un `Bill` más credenciales (`token`/`sign`/`cuit`/`pkey`/`cert`), arma el request, llama al web service y parsea la respuesta en capas independientes (resultado/CAE, `afip_errors`, `afip_events`, `afip_observations`); expone `set_bill_number!` y `authorize!`.
+- **`Snoopy::Bill`** (`bill.rb`): modela el comprobante; valida con `valid?`/`errors` y consulta estado de aprobación con `approved?`, `partial_approved?`, `rejected?`.
+- **`Snoopy::Constants`** (`constants.rb`) y **`Snoopy::Exception`** (`exceptions.rb`): tablas de dominio (tipos de documento, alícuotas, condiciones de IVA) y jerarquía de excepciones.
+- **`lib/snoopy_afip/core_ext/`**: extensiones a `String`, `Hash` y `Float`.
+
+El acoplamiento de las capas de parseo es deliberado (ver README §"No Explota"): un cambio de formato de AFIP en una capa no debe tumbar el parseo de las demás.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,15 @@
+# Claude Code Notes
+
+## Fuente de verdad del repositorio
+
+Las reglas, convenciones, estructura y contexto del proyecto viven en `AGENTS.md`.
+
+- Leer `AGENTS.md` antes de hacer cambios.
+- Tratar `AGENTS.md` como fuente de verdad para identidad, estructura, documentación, convenciones del framework, entorno, y arquitectura.
+
+## Propósito de este archivo
+
+`CLAUDE.md` queda reservado para instrucciones o notas específicas de Claude Code.
+
+- No duplicar aquí reglas generales del repositorio.
+- Si una regla aplica a cualquier agente, moverla a `AGENTS.md`.

--- a/README.md
+++ b/README.md
@@ -1,238 +1,136 @@
 # snoopy_afip
-conexión con Web Service de Factura Electrónica de AFIP (WSFE)
+
+Gema Ruby que adapta la **Facturación Electrónica de AFIP (Argentina)**. Expone el módulo `Snoopy` y resuelve, vía SOAP (`savon`), los dos servicios de AFIP necesarios para emitir comprobantes electrónicos:
+
+- **WSAA** (autenticación): obtiene `token`/`sign` a partir de clave privada + certificado.
+- **WSFE** (facturación electrónica v1): autoriza facturas y notas de crédito, devuelve el CAE.
+
+Versión actual: `4.3.0`.
 
 ## Instalación
 
-Añadir esta linea en el Gemfile:
-
 ```ruby
+# Gemfile
 gem 'snoopy_afip'
 ```
 
-Luego ejecuta:
+```bash
+bundle install
+# o
+gem install snoopy_afip
+```
 
-    $ bundle
+## Setup (desarrollo)
 
-O instala la gema a mano:
+```bash
+bundle install
+bundle exec rspec   # ver estado de la suite en docs/test/testing.md
+```
 
-    $ gem install snoopy_afip
+Dependencia de runtime: `savon ~> 2.12.1`. Gestión de Ruby con **chruby**, dependencias con **Bundler**.
 
-### Versiones
+## Configuración
 
-- `2.1.1`. Usada en producción. (**Stable**)
-- `3.0.0`. Aun en entorono de testing. (**Beta**)
-
-## Antes que nada
-
-* Link con el manual para desarrolladores.
-
-- [Especificación Técnica WSAA]('http://www.afip.gov.ar/ws/WSAA/Especificacion_Tecnica_WSAA_1.2.0.pdf'): Especificación técnica para la comunicación con el **WSAA** (servicio de autenticación), su propósito es solicitar un _tocken_ y _sign_ para poder emitir facturas con el servicio de **WSFE** (Servicio de autorización de facturas)
-
-- [Manual desarrollador](http://www.afip.gob.ar/fe/documentos/manual_desarrollador_COMPG_v2_9.pdf): Especificación técnica para la comunicación con **WSFE** (Servicio de autorización de facturas).
-
-* Es recomendable descargar los **Wsdl** para evitar tener que pedirlo en cada request
-
-- Wsdl **WSAA** (servicio de autenticación)
-
-  - Testing:    [https://wsaahomo.afip.gov.ar/ws/services/LoginCms?wsdl]('https://wsaahomo.afip.gov.ar/ws/services/LoginCms?wsdl')
-  - Producción: [https://wsaa.afip.gov.ar/ws/services/LoginCms?wsdl]('https://wsaa.afip.gov.ar/ws/services/LoginCms?wsdl')
-
-- **WSFE** (Servicio de autorización de facturas)
-
-  - Testing:    [https://wswhomo.afip.gov.ar/wsfev1/service.asmx?wsdl]('https://wswhomo.afip.gov.ar/wsfev1/service.asmx?wsdl')
-  - Producción: [https://servicios1.afip.gov.ar/wsfev1/service.asmx?WSDL]('https://servicios1.afip.gov.ar/wsfev1/service.asmx?WSDL')
-
-* Explicación detallada de los pasos a seguir para obtener el certificado desde el sitio web AFIP para emitir facturas electrónicas.
-
-[obtención de certificado](https://www.afip.gob.ar/ws/WSAA/WSAA.ObtenerCertificado.pdf)
-
-## USO
-
-### Inicialización de parametros generales
+La gema se configura en el host (típicamente `config/initializers/snoopy.rb`):
 
 ```ruby
 Snoopy.default_currency      = :peso
 Snoopy.default_concept       = 'Servicios'
-Snoopy.default_document_type = 'CUIT' || 'DNI' # O alguna key de Snoopy::DOCUMENTS
-# Para el caso de produccion
-Snoopy.auth_url    = 'https://wsaa.afip.gov.ar/ws/services/LoginCms?wsdl' || PATH_WSAA_PROP_WSDL
-Snoopy.service_url = 'https://servicios1.afip.gov.ar/wsfev1/service.asmx?WSDL' || PATH_WSFE_PROP_WSDL
-# Para el caso de desarrollo
-Snoopy.auth_url    = 'https://wsaahomo.afip.gov.ar/ws/services/LoginCms?wsdl' || PATH_WSAA_TEST_WSDL
-Snoopy.service_url = 'https://wswhomo.afip.gov.ar/wsfev1/service.asmx?wsdl' || PATH_WSFE_TEST_WSDL
+Snoopy.default_document_type = 'CUIT'           # alguna key de Snoopy::DOCUMENTS
+
+# Homologación (testing)
+Snoopy.auth_url    = 'https://wsaahomo.afip.gov.ar/ws/services/LoginCms?wsdl'
+Snoopy.service_url = 'https://wswhomo.afip.gov.ar/wsfev1/service.asmx?wsdl'
+# Producción
+# Snoopy.auth_url    = 'https://wsaa.afip.gov.ar/ws/services/LoginCms?wsdl'
+# Snoopy.service_url = 'https://servicios1.afip.gov.ar/wsfev1/service.asmx?WSDL'
+
+Snoopy.pkey = '<path-o-PEM-de-la-clave-privada>'   # secreto — nunca commitear
+Snoopy.cert = '<path-o-PEM-del-certificado-AFIP>'  # secreto — nunca commitear
+Snoopy.cuit = '<CUIT-del-emisor>'
 ```
 
-En caso de trabajar con `Ruby on Rails`, es recomendable crear un archivo con esta conf en `config/initializers/snoopy.rb`.
+> El inventario completo de opciones (tipos, defaults, secretos, failure-mode) está en [`docs/config/configuracion.md`](docs/config/configuracion.md). Nunca incrustar CUIT, claves ni certificados reales en el código ni en el repo.
 
-### Generar Clave privada
+## Uso
+
+### 1. Autenticar (WSAA)
 
 ```ruby
-Snoopy::AuthenticationAdapter.generate_pkey(2048) # Si no se pasa argumento se generar una de 8192
+auth = Snoopy::AuthenticationAdapter.new(pkey: pkey_path, cert: cert_path)
+credentials = auth.authenticate!
+# => { token: "<token>", sign: "<sign>", expiration_time: <DateTime> }  (válido 12h)
 ```
 
-Este metodo retorna el `RAW` de la pkey, la cual debera guardarse en algun archivo o alguna base de datos.
+Helpers para generar clave/CSR: `Snoopy::AuthenticationAdapter.generate_pkey`, `.generate_certificate_request_with_ruby`, `.generate_certificate_request_with_bash`. Trámite del certificado: [AFIP — Obtener certificado](https://www.afip.gob.ar/ws/WSAA/WSAA.ObtenerCertificado.pdf).
 
-### Generar solicitud de pedido de certificado
-
-#### With ruby
-
-Este metodo aun no ha sido testeado, por lo que agredezco si alguien logra probarlo.
+### 2. Crear el comprobante (`Bill`)
 
 ```ruby
-Snoopy::AuthenticationAdapter.generate_certificate_request_with_ruby(pkey_path, subj_o, subj_cn, subj_cuit)
+bill = Snoopy::Bill.new(
+  cuit:                   cuit,
+  sale_point:             sale_point,
+  concept:                'Servicios',
+  document_type:          'CUIT',
+  document_num:           '30710151543',
+  issuer_iva_cond:        Snoopy::RESPONSABLE_INSCRIPTO,
+  receiver_iva_cond:      :factura_a,           # key de Snoopy::BILL_TYPE → cbte_type
+  receiver_iva_condition: :responsable_inscripto,
+  total_net:             1000.0,
+  alicivas: [ { id: 0.21, amount: 210.0, taxeable_base: 1000.0 } ]
+)
+bill.valid?   # corre validaciones → bill.errors
 ```
 
-#### With bash
+`alicivas` discrimina el IVA por ítem (`id` = porcentaje, `amount` = monto del impuesto, `taxeable_base` = neto sin IVA). Tasas soportadas: `Snoopy::ALIC_IVA`. Detalle de términos en [`docs/glossary/glossary.md`](docs/glossary/glossary.md).
 
-Mantiene la generación de versiones pasadas de `Snoopy`
-
-```bash
-Snoopy::AuthenticationAdapter.generate_certificate_request_with_bash(pkey_path, subj_o, subj_cn, subj_cuit)
-```
-
-- `pkey_path`: Ruta absoluta de la llave privada.
-- `subj_o`: Nombre de la compañia.
-- `subj_cn`: Hostname del server que generará las solicitudes. En ruby se obtiene con `%x(hostname).chomp`
-- `subj_cuit`: Cuit registrado en la AFIP de la compañia que emita facturas.
-
-Una vez generado este archivo debe hacerse el tramite en el sitio web de la **AFIP** para obtener el certificado que permitirá autorizar facturas al webservice.
-
-### Solicitar autorización para la emisión de facturas
-
-Para poder emitir o autorizar facturas en el web service de la **AFIP** es necesario solicitar autorización.
+### 3. Autorizar (WSFE)
 
 ```ruby
-# pkey_path: Ruta absoluta de la llave privada.
-# cert_path: Ruta absoluta del cetificado obtendio del sitio oficial de la **AFIP**.
-authentication_adapter = Snoopy::AuthenticationAdapter.new(pkey_path, pkey_cert)
-authentication_adapter.authenticate!
+adapter = Snoopy::AuthorizeAdapter.new(
+  bill:  bill,
+  pkey:  pkey, cert: cert, cuit: cuit,
+  token: credentials[:token], sign: credentials[:sign]
+)
+adapter.set_bill_number!   # numera con el último autorizado + 1
+adapter.authorize!         # => true/false; setea bill.cae, bill.result, ...
 ```
 
-`authentication_adapter.authenticate!` deberá retornar un `Hash` con las siguientes keys: `:token`, `:sign` y `:expiration_time`
+Lecturas de la respuesta: `adapter.afip_errors`, `adapter.afip_events`, `adapter.afip_observations`, `adapter.errors`, `adapter.response`. Estado del comprobante: `bill.approved?`, `bill.partial_approved?`, `bill.rejected?`.
 
-La key `:expiration_time` determina hasta cuando se podrá autorizar facturas, el tiempo esta prefijado por **AFIP** y es el de 24 Horas desde el momento de la solicitud del **token sign**, superado este tiempo deberá solicitarse nuevamente un **token sign**.
+### Manejo de errores
 
-```ruby
-# Response example
-{ token: "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9InllcyI/Pgo8c3NvIHZlcnNpb249IjIuMCI+CiAgICA8aWQgdW5pcXVlX2lkPSI5MDIxNDczOTEiIHNyYz0iQ049d3NhYWhvbW8sIE89QUZJUCwgQz1BUiwgU0VSSUFMTlVNQkVSPUNVSVQgMzM2OTM0NTAyMzkiIGdlbl90aW1lPSIxNDk4NDk0NDQ1IiBleHBfdGltZT0iMTQ5ODUzNzcwNSIgZHN0PSJDTj13c2ZlLCBPPUFGSVAsIEM9QVIiLz4KICAgIDxvcGVyYXRpb24gdmFsdWU9ImdyYW50ZWQiIHR5cGU9ImxvZ2luIj4KICAgICAgICA8bG9naW4gdWlkPSJDPWFyLCBPPXNlcXVyZSBzYSwgU0VSSUFMTlVNQkVSPUNVSVQgMjAyNDE2MDgxNjcsIENOPXBjIiBzZXJ2aWNlPSJ3c2ZlIiByZWdtZXRob2Q9IjIyIiBlbnRpdHk9IjMzNjkzNDUwMjM5IiBhdXRobWV0aG9kPSJjbXMiPgogICAgICAgICAgICA8cmVsYXRpb25zPgogICAgICAgICAgICAgICAgPHJlbGF0aW9uIHJlbHR5cGU9IjQiIGtleT0iMjAyNDE2MDgxNjciLz4KICAgICAgICAgICAgPC9yZWxhdGlvbnM+CiAgICAgICAgPC9sb2dpbj4KICAgIDwvb3BlcmF0aW9uPgo8L3Nzbz4KCg==",
-  sign: "iSpp/5qxQntuzOQcqs6GlShFaOKtEagLY17TFDwMTiErquT/fEw5ki9Ff4RYGndc/49UGmUTnVjUqB0mxuJk2IG4t+J4AAyVsY6+xiBGvMXAM/5sAI78NDl7ibMxAcdPi+nBIrdydp5DLy2SB4u/G46kguc6+srBp2fo20f/+wM=",
-  expiration_time: #<DateTime: 2017-06-27T01:28:25-03:00 ((2457932j,16105s,963000000n),-10800s,2299161j)>}}
-```
+- **Explota** (`raise`): fallo de comunicación con AFIP (`Snoopy::Exception::ServerTimeout`, `ClientError`) → no se autorizó el comprobante.
+- **No explota**: AFIP respondió pero el parseo de la respuesta falló o devolvió errores de negocio → se acumulan en `adapter.errors` / `afip_errors` (parseo en 4 capas independientes para que un cambio de formato de AFIP no tumbe todo).
 
-En caso de producirse algun tipo de error este será devuelto a traves de raise exception. El error mas comun puede deberse al que certificado obtenido a treves del pedido de cetificado no sea correcto.
+Catálogo y política completos en [`docs/errors/errors.md`](docs/errors/errors.md).
 
-### Autorizar factura
+## Índice de artefactos (`docs/`)
 
-#### Crear `Bill`
-```ruby
-Snoopy::Bill.new(attrs)
+| capa | artefacto | contenido |
+|---|---|---|
+| interfaz | [`docs/interface/interface.md`](docs/interface/interface.md) | API Ruby pública (`Snoopy`, adapters, `Bill`, constantes) |
+| comportamiento | [`docs/behavior/behavior.md`](docs/behavior/behavior.md) | secuencias WSAA / WSFE |
+| glosario | [`docs/glossary/glossary.md`](docs/glossary/glossary.md) | términos AFIP (CAE, cbte_type, alicivas, IVA cond) |
+| consumidas | [`docs/consumed/afip.md`](docs/consumed/afip.md) | contrato SOAP consumido (WSAA + WSFE) |
+| errores | [`docs/errors/errors.md`](docs/errors/errors.md) | jerarquía `Snoopy::Exception::*` + política |
+| configuración | [`docs/config/configuracion.md`](docs/config/configuracion.md) | inventario de opciones runtime |
+| topología | [`docs/topology/topology.md`](docs/topology/topology.md) | dependencias + servicios externos |
+| test | [`docs/test/testing.md`](docs/test/testing.md) | suite, gaps de cobertura |
+| operaciones (api) | n/a | gema sin superficie HTTP/CLI propia |
+| datos | n/a | sin base de datos |
+| eventos · multi-tenancy | n/a | no aplica |
 
-```
-Donde `attrs` debe estar conformado de la siguiente manera:
-* `attrs[:cuit]`                    CUIT del emisor de la factura.
-* `attrs[:concept]`                 Concepto de la factura, por defecto `Snoopy.default_concept`.
-* `attrs[:imp_iva]`                 Monto total de impuestos.
-* `attrs[:currency]`                Tipo de moneda a utilizar, por default `Snoopy.default_currency`.
-* `attrs[:alicivas]`                Impuestos asociados a la factura.
-* `attrs[:total_net]`               Monto neto por defecto es 0.
-* `attrs[:sale_point]`              Punto de venta del emisor de la factura.
-* `attrs[:document_type]`           Tipo de documento a utilizar, por default `Snoopy.default_document`. Valores posibles `Snoopy::DOCUMENTS`
-* `attrs[:document_num]`            Numero de documento o cuit, el valor depende de `attrs[:document_type]`.
-* `attrs[:issuer_iva_cond]`         Condición de IVA del emisor de la factura. [`Snoopy::RESPONSABLE_INSCRIPTO` o `Snoopy::RESPONSABLE_MONOTRIBUTO`]
-* `attrs[:receiver_iva_cond]`       valores posibles `Snoopy::BILL_TYPE`
-* `attrs[:service_date_from]`       Inicio de vigencia de la factura.
-* `attrs[:service_date_to]`         Fin de vigencia de la factura.
-* `attrs[:cbte_asoc_num]`           Numero de la factura a la cual se quiere crear una nota de crédito (Solo pasar si se esta creando una nota de crédito).
-* `attrs[:cbte_asoc_to_sale_point]` Punto de venta de la factura a la cual se quiere crear una nota de crédito (Solo pasar si se esta creando una nota de crédito).
+## Referencias AFIP
 
-El `attrs[:alicivas]` discrimina la información de los items. Es posible que en la factura se discriminen diferentes items con diferentes impuestos. Para ello el `attrs[:alicivas]` es un arreglo de `Hash`. Donde cada uno de ellos tiene la información sobre un determinado impuesto.
-
-```ruby
-{ id:            tax_rate.round_with_precision(2),    # Porcentaje. Ej: "0.105", "0.21", "0.27"
-  amount:        tax_amount.round_with_precision(2),  # Monto total del impuesto del item.
-  taxeable_base: net_amount.round_with_precision(2) } # Monto total del item sin considerar el impuesto.
-```
-
-Por ejemplo si se tiene 5 items, donde 3 de ellos tienen un impuesto del 10.5% y los 2 restantes del 21%. Los primeros 3 deben, se debera de crear dos hashes de la siguientes forma.
-
-```ruby
-attrs[:alicivas] = [ { id: (10.5 / 100 ).to_s 
-                       amount: X,            # De los 3 items de 10.5
-                       taxeable_base: Y },   # De los 3 items de 10.5
-                     { id: (21 / 100 ).to_s 
-                       amount: X,            # De los 2 items de 21
-                       taxeable_base: Y } ]  # De los 2 items de 21
-```
-Donde: 
-
-* `X`: Es la parte del monto que le corresponde al impuesto.
-* `Y`: Es la partes del monto sin impuesto.
-
-Los `tax_rates` soportados por AFIP son los siguientes:
-
-```ruby
-Snoopy::ALIC_IVA
-```
-
-* Tips:
-
-El `taxeable_base` se calcula de la siguiente manera:
-
-```ruby
-total_amount / (1 + tax_percentage)
-```
-  
-- Metodos de interes
-  - **valid?**            valida si la `bill` cumple lo minimo indispensable.
-  - **partial_approved?** si fue _Aprobada parcialmente_ por el webserice.
-  - **rejected?**         si fue _Rechazada_ por el webservice.
-  - **approved?**         si fue _Aprobada_ por el webservice.
-  - **errors**            errores presentados durante la validación `valid?`
-
-#### Autorizar el `Bill`
-```ruby
-authorize_adapter = Snoopy::AuthorizeAdapter.new({ bill: bill,        # Obtenido en el paso anterior
-                                                   pkey: pkey,        # PATH de la clave privada generada anteriormente.
-                                                   cert: certificate, # PATH del certificado descargado del sitio web de la AFIP.
-                                                   cuit: cuit,        # CUIT del emisor de la factura, mismo con el que se hizo el tramite.
-                                                   sign: sign,        # SIGN obtenido en la autenticación
-                                                   token: token})     # TOKEN obtenido en la autenticación
-                                                   
-authorize_adapter.set_bill_number!
-
-authorize_adapter.authorize!
-```
-
-- Metodos de interes del `Snoopy::AuthorizeAdapter`
-
-  - **request** Información enviada al webservice de **AFIP**
-  - **response** Respuesta completa obtenida del webservice de **AFIP**
-  - **afip_errors** Errores parseados de la **response**. Pueden presentarse los motivos por los que no se autorizo la `bill`
-  - **afip_events** Eventos parseados de la **response** . Generalmente la **AFIP** los usa para informar de posibles cambios.
-  - **afip_observations** Observaciones parseados de la **response**. Pueden presentarse los motivos por los que no se autorizo la `bill`
-  - **errors** Errores presentados en el proceso de autorización. Explicado en el apartado siguiente.
-
-### Manejo de excepciones
-
-#### Explota
-
-Hay errores que producirán que `Snoopy` generé un `raise`, estos son los casos que se produzcan errores previo o durante la comunicación con la **AFIP**. En estos casos se produce un `raise` debido a que no se logro la comunicación con la **AFIP** por lo que se puede asegurar que no se autorizo la `bill`
-
-#### No Explota
-Existe otro caso que se produzca un error posterior a la comunicación con el webservice, en este caso se pudo obtener una respuesta , pero se producierón errores en el parseo de la misma (Por ejemplo **AFIP** cambia el formato de la response), para ellos se puede consultar las exceptiones generadas por los parseadores con `authorize_adapter.errors`. 
-
-Hay 4 nivel de parser:
-- **Obtención del resultado, cae, fecha de vencimiento del cae y el bill number**: Este es el nivel de parser mas **importante** dado que si este no se pudo realizar, es imposible saber que sucedio durante la autorización. Pero no preocuparse por que esta la response completa en `authorize_adapter.response`
-- **Parseo de errores**: Parsea los errores retornados por la **AFIP**.
-- **Parseo de eventos**: Parsea los eventos retornados por la **AFIP**.
-- **Parseo de observaciones**: Parsea las observaciones retornados por la **AFIP**.
-
-Implemente esto de esta manera debido a que sucedio que **AFIP** cambio algo en la estructura de los eventos, y al tener todo en un solo parser explotaba todo y no sabia que habia sucedido con la autorización de la factura.
+- [Especificación Técnica WSAA 1.2.0](http://www.afip.gov.ar/ws/WSAA/Especificacion_Tecnica_WSAA_1.2.0.pdf)
+- [Manual del desarrollador WSFE](http://www.afip.gob.ar/fe/documentos/manual_desarrollador_COMPG_v2_9.pdf)
 
 ## TO DO
-- **Mejor parseo de los errores obtenidos en AFIP**: La idea seria poder identificar cada uno de los errores posibles obtenido, y agregar los errores en la `bill` al atributo que corresponda.
-- **Batch**: Permitir a `Snoopy::AuthorizeAdapter` autorizar un pool de `Snoopy::Bill` en una sola request.
+
+- Mejor parseo de los errores de AFIP (mapear cada código al atributo del `Bill`).
+- Batch: autorizar un pool de `Bill` en una sola request.
 
 ## License
 
-The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
+MIT — ver [LICENSE.txt](LICENSE.txt).

--- a/docs/behavior/behavior.md
+++ b/docs/behavior/behavior.md
@@ -1,0 +1,84 @@
+# Comportamiento — snoopy_afip
+> meta: artefacto · RFC-007 · generado arch-enrich · anclado a 7813cf2 · cobertura: 3 flujos documentados / 0 pendientes localizados
+
+## Cobertura
+
+| flujo | estado |
+|---|---|
+| Autenticación WSAA (`authenticate!`) | documentado |
+| Numeración del comprobante (`set_bill_number!`) | documentado |
+| Autorización WSFE (`authorize!`) | documentado |
+| Consulta de comprobante (`invoice_informed?`) | no documentado (variante de lectura de `fe_comp_consultar`) |
+
+## 1. Resumen
+
+Dos flujos de negocio encadenados: autenticación (WSAA, una vez por 12h) y autorización (WSFE, por comprobante). El segundo asume credenciales ya obtenidas. El diseño separa el parseo de la respuesta WSFE en capas que no se tumban entre sí.
+
+## 2. Flujos
+
+### Autenticación WSAA — `authenticate!`
+
+Contexto: obtiene `token`/`sign` firmando un TRA con cert+pkey.
+
+```mermaid
+sequenceDiagram
+  participant Host
+  participant Auth as AuthenticationAdapter
+  participant Cli as Client
+  participant WSAA as AFIP WSAA
+  Host->>Auth: new(pkey, cert)
+  Host->>Auth: authenticate!
+  Auth->>Auth: build_tra (XML loginTicketRequest)
+  Auth->>Auth: build_cms (PKCS7 sign cert+pkey)
+  Auth->>Cli: call(:login_cms, in0 cms)
+  Cli->>WSAA: SOAP login_cms
+  WSAA-->>Cli: loginTicketResponse
+  Cli-->>Auth: body
+  Auth->>Auth: Nori.parse + extrae credentials
+  Auth-->>Host: {token, sign, expiration_time}
+```
+
+### Autorización WSFE — `set_bill_number!` + `authorize!`
+
+Contexto: numera y autoriza un `Bill` válido; setea CAE y parsea errores/eventos/observaciones en capas independientes.
+
+```mermaid
+sequenceDiagram
+  participant Host
+  participant Adapter as AuthorizeAdapter
+  participant Bill
+  participant Cli as Client
+  participant WSFE as AFIP WSFE
+  Host->>Adapter: new(bill, token, sign, cuit, pkey, cert)
+  Host->>Adapter: set_bill_number!
+  Adapter->>Cli: call(:fe_comp_ultimo_autorizado)
+  Cli->>WSFE: SOAP
+  WSFE-->>Adapter: cbte_nro
+  Adapter->>Bill: number = cbte_nro + 1
+  Host->>Adapter: authorize!
+  Adapter->>Bill: valid?
+  alt bill invalido
+    Adapter-->>Host: false
+  else valido
+    Adapter->>Adapter: build_body_request (FeCAEReq)
+    Adapter->>Cli: call(:fecae_solicitar)
+    Cli->>WSFE: SOAP
+    WSFE-->>Adapter: FECAEDetResponse
+    Adapter->>Bill: cae, due_date_cae, result, number
+    Adapter->>Adapter: parse_errors / parse_events / parse_observations
+    Adapter-->>Host: true
+  end
+```
+
+## 3. Inferencias
+
+| ítem | confidence | a verificar |
+|---|---|---|
+| `set_bill_number!` se llama antes de `authorize!` | inferred | el README los muestra en ese orden; confirmar si `authorize!` exige número previo |
+| El parseo en capas no propaga (acumula en `errors`/`afip_*`) | declared | diseño "No Explota" del README; confirmado en código |
+
+## 4. Cobertura y fronteras
+
+- `invoice_informed?` (lectura `fe_comp_consultar`) no diagramado — acreta en próximo PR que lo toque.
+- La firma CMS/OpenSSL detallada (PKCS7) no se desglosa; ver `build_cms`.
+- Comportamiento de fallo (timeout/degradación) → `docs/consumed/afip.md §e`.

--- a/docs/config/configuracion.md
+++ b/docs/config/configuracion.md
@@ -1,0 +1,94 @@
+# Configuración runtime — snoopy_afip
+> meta: artefacto · RFC-012 · generado arch-structure · enriquecido arch-enrich · anclado a 7813cf2 · cobertura: inventario base 14/14; §f 6/14
+
+## 2.a Hecho verificable
+
+| métrica | valor |
+|---|---|
+| total opciones | 14 |
+| requeridas | 0 (ninguna lanza sin default; faltantes fallan en uso, no en boot) |
+| con default | 3 (`open_timeout`, `read_timeout`, `SNOOPY_SSL_VERSION`) |
+| derivadas | 0 |
+| secretas | 2 (`pkey`, `cert`) |
+| origen ENV | 1 (`SNOOPY_SSL_VERSION`) |
+
+Es **gema con configuración pública**: el grueso se setea por código en el host (`Snoopy.<attr> = …`, típicamente un initializer), no por ENV.
+
+## 2.b Inventario base
+
+| nombre | tipo | requerida | default | origen | consumidor | secret? |
+|---|---|---|---|---|---|---|
+| `Snoopy.cuit` | String | no | `nil` | code-default | `auth_hash`, `AuthorizeAdapter#auth` | no |
+| `Snoopy.sale_point` | String | no | `nil` | code-default | host / `Bill#sale_point` | no |
+| `Snoopy.service_url` | String (URL/WSDL) | no | `nil` | code-default | `AuthorizeAdapter#client_configuration:186` | no |
+| `Snoopy.auth_url` | String (URL/WSDL) | no | `nil` | code-default | `AuthenticationAdapter#client_configuration:115` | no |
+| `Snoopy.pkey` | String (path/PEM) | no | `nil` | code-default | `AuthorizeAdapter#client_configuration:193` | **sí** |
+| `Snoopy.cert` | String (path/PEM) | no | `nil` | code-default | `AuthorizeAdapter#client_configuration:192` | **sí** |
+| `Snoopy.default_document_type` | String | no | `nil` | code-default | `Bill#initialize:30` | no |
+| `Snoopy.default_concept` | String | no | `nil` | code-default | `Bill#initialize:22` | no |
+| `Snoopy.default_currency` | Symbol | no | `nil` | code-default | `Bill#initialize:24` | no |
+| `Snoopy.own_iva_cond` | Symbol | no | `nil` | code-default | host | no |
+| `Snoopy.verbose` | String/bool | no | `nil` | code-default | `snoopy_afip.rb:55` (comentado) | no |
+| `Snoopy.open_timeout` | Integer | no | `30` | code-default (`lib/snoopy_afip.rb:23`) | `Client#call:10`, `AuthorizeAdapter:191` | no |
+| `Snoopy.read_timeout` | Integer | no | `30` | code-default (`lib/snoopy_afip.rb:24`) | `AuthorizeAdapter:190` | no |
+| `SNOOPY_SSL_VERSION` | Symbol | no | `:TLSv1` | env (`constants.rb:24`) | `client_configuration` (ambos adapters) | no |
+
+## 2.c Meta-templates
+
+Ninguna (sin patrones `{SERVICE}_{HOST|PORT}` repetidos).
+
+## 2.d Derivaciones simples
+
+- `Snoopy::SNOOPY_SSL_VERSION = (ENV['SNOOPY_SSL_VERSION'] || 'TLSv1').to_sym` — leído **una vez al cargar** `constants.rb` y **congelado** como constante (cambiar el ENV en runtime no tiene efecto).
+
+## 2.e Scheduling
+
+`n/a` (sin sidekiq/queue/cron).
+
+## 2.i Inyecciones al host
+
+- **Monkey-patches globales** (cargados incondicionalmente en `lib/snoopy_afip.rb:7-9`): `core_ext/float.rb`, `core_ext/hash.rb`, `core_ext/string.rb` reabren `Float`/`Hash`/`String`. `Float#round_with_precision`/`round_up_with_precision` y `String#underscore` se redefinen **siempre**; los de `Hash` solo `unless method_defined?`. Sin Railtie/Engine.
+
+## 2.j Inyección a gemas configuradas
+
+`—` (no aplica: no configura gemas de terceros vía bloque).
+
+## 3. Inferencias
+
+| ítem | confidence | a verificar |
+|---|---|---|
+| `secret?` de `pkey`/`cert` por contenido (clave privada + certificado), no por nombre | inferred | confirmar manejo (¿path en disco vs PEM inline?) |
+| `verbose` consumido solo en línea comentada (`snoopy_afip.rb:55`) | declared | accessor vivo pero sin efecto actual — posible config muerta |
+
+## f. Enriquecimiento semántico
+
+> cobertura: 6/14 vars enriquecidas; ausencia ≠ "no aplica".
+
+### f.1 credenciales (`cuit`, `pkey`, `cert`)
+
+| var | categoría | failure-mode | side-effect | scope-override | business-reason / definición |
+|---|---|---|---|---|---|
+| `Snoopy.pkey` | infra | runtime-error al firmar CMS (`CmsBuilder`) si falta/inválida | restart (se relee por request al construir cliente) | mutable-singleton | clave privada que firma el CMS de WSAA y el mTLS de WSFE; **secreto** |
+| `Snoopy.cert` | infra | runtime-error (`CmsBuilder`) / handshake TLS si inválido | restart | mutable-singleton | certificado emitido por AFIP; identifica al emisor; **secreto** |
+| `Snoopy.cuit` | business | request rechazado por AFIP si no coincide con el cert | per-request | mutable-singleton | CUIT del emisor; debe coincidir con el del trámite del certificado |
+
+### f.2 endpoints (`auth_url`, `service_url`)
+
+| var | categoría | failure-mode | side-effect | scope-override | business-reason / definición |
+|---|---|---|---|---|---|
+| `Snoopy.auth_url` | integration | `ClientError` (WSDL inalcanzable) | restart | mutable-singleton | WSDL de WSAA; **homologación vs producción** se elige acá (riesgo: emitir contra prod por error) |
+| `Snoopy.service_url` | integration | `ClientError` | restart | mutable-singleton | WSDL de WSFE; mismo riesgo homo/prod |
+
+### f.3 tuning de red (`open_timeout`, `read_timeout`, `SNOOPY_SSL_VERSION`)
+
+| var | categoría | failure-mode | side-effect | scope-override | business-reason / definición |
+|---|---|---|---|---|---|
+| `SNOOPY_SSL_VERSION` | tuning | handshake TLS falla si AFIP no soporta la versión | **compile-time-only** (congelado al cargar `constants.rb`) | boot-only | default `:TLSv1` quedó **desactualizado** — AFIP exige TLS ≥1.2; revisar (`inferred`) |
+
+**Ramificadores:** `issuer_iva_cond = :responsable_monotributo` ramifica `alicivas` (monotributo no informa IVA — `authorize_adapter.rb:75`). Es ramificador de payload, no intra-config.
+
+## 4. Cobertura y fronteras
+
+- **Valores reales prohibidos**: solo shape. CUIT/pkey/cert se setean en el host; nunca commitear valores.
+- `ENV["CUIT"]` aparece en `spec/spec_helper.rb` pero es **config de test**, no de la gema → ver `docs/test/`.
+- Enriquecimiento (`categoría`, `failure-mode`, `side-effect`, `business reason`, threading) → arch-enrich (§f).

--- a/docs/consumed/afip.md
+++ b/docs/consumed/afip.md
@@ -1,0 +1,61 @@
+# Dependencias consumidas — AFIP (WSAA + WSFE)
+> meta: artefacto · RFC-018 · generado arch-structure · enriquecido arch-enrich · anclado a 7813cf2 · cobertura: subset SOAP invocado; §c 1/1 · §e 1/1
+
+Entrada de **familia** (RFC-018 §4 r2): ambos servicios externos se invocan por el mismo cliente base `Snoopy::Client` (wrapper de `Savon.client`). Difieren en WSDL, headers y operaciones.
+
+## 2.a Identidad
+
+| campo | valor |
+|---|---|
+| proveedor / servicio | AFIP (Argentina) — Facturación Electrónica |
+| sub-tipo | **externo** |
+| transporte | SOAP sobre HTTP/HTTPS |
+| cliente nuestro | `Snoopy::Client` (`lib/snoopy_afip/client.rb`) sobre `savon` |
+| auth | WSAA: firma CMS/PKCS7 (cert + pkey) → `token`/`sign`. WSFE: `Auth = {Token, Sign, Cuit}` + mTLS (`ssl_cert_file`/`ssl_cert_key_file`) |
+| ancla | doc oficial AFIP — ver §5 |
+
+### Miembros de la familia
+
+| miembro | WSDL (config) | cliente | particularidades |
+|---|---|---|---|
+| **WSAA** (autenticación) | `Snoopy.auth_url` | `AuthenticationAdapter#client_configuration` | `ssl_version`, `pretty_print_xml`; sin headers extra |
+| **WSFE** (facturación electrónica v1) | `Snoopy.service_url` | `AuthorizeAdapter#client_configuration` | headers `Accept-Encoding`/`Connection`; namespace `http://ar.gov.afip.dif.FEV1/`; mTLS con `cert`/`pkey`; `read_timeout`/`open_timeout` |
+
+## 2.b Operaciones consumidas (subset usado)
+
+| servicio | operación SOAP | destino (código) | qué mandamos / esperamos |
+|---|---|---|---|
+| WSAA | `:login_cms` | `AuthenticationAdapter#authenticate!` | enviamos CMS firmado (TRA `loginTicketRequest`, service=`wsfe`); esperamos `loginTicketResponse` con `credentials.token`/`.sign` + `header.expirationTime` |
+| WSFE | `:fecae_solicitar` | `AuthorizeAdapter#authorize!` | enviamos `Auth` + `FeCAEReq` (cabecera + detalle: tipo, punto venta, importes, IVA, doc, fechas); esperamos `FECAEDetResponse` con `cae`, `cae_fch_vto`, `resultado`, `cbte_desde` + `errors`/`events`/`observaciones` |
+| WSFE | `:fe_comp_ultimo_autorizado` | `AuthorizeAdapter#set_bill_number!` | enviamos `Auth` + `PtoVta` + `CbteTipo`; esperamos `cbte_nro` (último autorizado) → `+1` |
+| WSFE | `:fe_comp_consultar` | `AuthorizeAdapter#invoice_informed?` | enviamos `Auth` + `FeCompConsReq` (tipo, nro, punto venta); esperamos `result_get` con estado del comprobante |
+
+## 2.c Semántica de retry / idempotencia
+
+- **La gema NO reintenta**: `Client#call` envuelve la llamada en `Timeout` y al fallar levanta `ServerTimeout`/`ClientError` — el retry queda a cargo del host.
+- **`authorize!` (`fecae_solicitar`) NO es idempotente por sí solo**: reenviar el mismo `FeCAEReq` puede generar un comprobante nuevo. La idempotencia se logra usando `set_bill_number!` (lee el último autorizado) o `invoice_informed?` (`fe_comp_consultar`) para verificar antes de reintentar. Reintentar a ciegas tras timeout es **inseguro**: el comprobante pudo haberse autorizado del lado de AFIP. `inferred` — confirmar política con AFIP.
+- **`set_bill_number!` / `invoice_informed?` (lecturas) son idempotentes**: reintento seguro.
+
+## 2.d Errores del proveedor → mapeo nuestro
+
+| condición del proveedor | excepción nuestra (ver `docs/errors/`) |
+|---|---|
+| `Timeout::Error` (corte por `Timeout::timeout(Snoopy.open_timeout)`) | `Snoopy::Exception::ServerTimeout` |
+| cualquier otro fallo de transporte/SOAP (`rescue => e`) | `Snoopy::Exception::ClientError` (con `e.message`) |
+| errores de negocio AFIP (`FeCAEReq` rechazado, etc.) | **no se levantan**: se parsean a `afip_errors`/`afip_events`/`afip_observations` (code→msg) y el flujo sigue |
+| fallo de parseo de la respuesta AFIP | excepciones `Snoopy::Exception::AuthorizeAdapter::*Parser` (ver `docs/errors/`) |
+
+Códigos de error documentados por AFIP para WSAA (`coe.notAuthorized`, `cms.*`, `xml.*`, `wsn.*`, `wsaa.*`) están listados como comentario en `authentication_adapter.rb:17-35` — referencia, no se mapean uno a uno.
+
+## 2.e Degradación
+
+- Si AFIP **no responde** (timeout/red): `Snoopy::Exception::ServerTimeout`/`ClientError` propaga al host. No hay fallback ni cola en la gema — la emisión del comprobante **no procede**. El host decide reintento/cola.
+- Si AFIP responde pero **rechaza** (errores de negocio): no hay excepción; `afip_errors` se puebla y `bill.result` queda `R`/`P`. La degradación es "comprobante no aprobado", consultable sin reintentar la red.
+- **SLA de AFIP**: no garantizado; ventanas de mantenimiento frecuentes (códigos `wsn.unavailable`/`wsaa.unavailable`). Diseñar el host para tolerar caídas. `inferred`.
+
+## 5. Cobertura y fronteras
+
+- Subset invocado, **no** la API completa de WSFE (la gema usa 4 operaciones de las ~decenas del WS).
+- Timeout/SSL: `open_timeout`/`read_timeout` (default 30) y `SNOOPY_SSL_VERSION` parametrizados en el repo → ver `docs/config/`.
+- Doc oficial: [Espec. Técnica WSAA 1.2.0](http://www.afip.gov.ar/ws/WSAA/Especificacion_Tecnica_WSAA_1.2.0.pdf) · [Manual desarrollador WSFE](http://www.afip.gob.ar/fe/documentos/manual_desarrollador_COMPG_v2_9.pdf).
+- WSDLs: WSAA homo `wsaahomo.afip.gov.ar` / prod `wsaa.afip.gov.ar`; WSFE homo `wswhomo.afip.gov.ar` / prod `servicios1.afip.gov.ar`.

--- a/docs/errors/errors.md
+++ b/docs/errors/errors.md
@@ -1,0 +1,69 @@
+# Errores / fallos públicos — snoopy_afip
+> meta: artefacto · RFC-020 · generado arch-structure · enriquecido arch-enrich · anclado a 7813cf2 · cobertura: jerarquía `Snoopy::Exception::*`; §c 13/13
+
+## 1. Resumen
+
+Gema sin superficie HTTP → no hay códigos de estado (§b n/a). El contrato del unhappy path es la jerarquía de excepciones `Snoopy::Exception::*` que la gema **levanta** hacia el host, más el patrón "no explota": los errores de negocio de AFIP no se levantan, se acumulan en hashes (`afip_errors`/`afip_events`/`afip_observations`) y los fallos de parseo se acumulan en `errors`.
+
+## 2.a Inventario de excepciones públicas
+
+| excepción | jerarquía base | qué la levanta |
+|---|---|---|
+| `Snoopy::Exception::Exception` | `< ::StandardError` | base de la gema; `initialize(msg, backtrace)` |
+| `Snoopy::Exception::ClientError` | `< Exception` | `Client#call` ante cualquier fallo no-timeout de la llamada SOAP |
+| `Snoopy::Exception::ServerTimeout` | `< Timeout::Error` | `Client#call` cuando expira `Timeout::timeout(Snoopy.open_timeout)` — **no** hereda de la base de la gema |
+| `Snoopy::Exception::AuthenticationAdapter::CmsBuilder` | `< Exception` | `AuthenticationAdapter#build_cms` si falla la firma PKCS7 / lectura de pkey-cert |
+| `Snoopy::Exception::AuthorizeAdapter::SetBillNumberParser` | `< Exception` | `#set_bill_number!` ante fallo de parseo de `fe_comp_ultimo_autorizado` |
+| `Snoopy::Exception::AuthorizeAdapter::BuildBodyRequest` | `< Exception` | `#build_body_request` si falla armar el `FeCAEReq` |
+| `Snoopy::Exception::AuthorizeAdapter::FecaeSolicitarResultParser` | `< Exception` | `#parse_fecae_solicitar_response` (capa resultado/CAE) |
+| `Snoopy::Exception::AuthorizeAdapter::FecaeResponseParser` | `< Exception` | `#parse_fecae_solicitar_response` (capa response) — se **acumula** en `errors`, no se raise-a |
+| `Snoopy::Exception::AuthorizeAdapter::ObservationParser` | `< Exception` | `#parse_observations` — se acumula en `errors` |
+| `Snoopy::Exception::AuthorizeAdapter::ErrorParser` | `< Exception` | `#parse_errors` — se acumula en `errors` |
+| `Snoopy::Exception::AuthorizeAdapter::EventsParser` | `< Exception` | `#parse_events` — se acumula en `errors` |
+| `Snoopy::Exception::Bill::MissingAttributes` | `< Exception` | validación de presencia (`Bill#valid?`) — mensaje, se acumula en `bill.errors` |
+| `Snoopy::Exception::Bill::InvalidValueAttribute` | `< Exception` | validación de valor estándar (currency/iva/doc/concept) — se acumula en `bill.errors` |
+
+## 2.b Códigos HTTP por superficie
+
+`n/a` — la gema no expone superficie HTTP (no hay controllers/routes). El transporte HTTP lo gestiona `savon` internamente.
+
+## 2.c Política por error
+
+| excepción | retriable? | backoff | idempotencia req. | acción |
+|---|---|---|---|---|
+| `ServerTimeout` | condicional | sí (host) | **sí** — verificar con `invoice_informed?` antes de reintentar `authorize!` | propagate + report |
+| `ClientError` | condicional | sí (host) | sí (idem) | propagate + report |
+| `AuthenticationAdapter::CmsBuilder` | no | — | — | propagate (config/cert inválido — no reintentable) |
+| `AuthorizeAdapter::BuildBodyRequest` | no | — | — | propagate (datos del bill mal formados) |
+| `AuthorizeAdapter::SetBillNumberParser` | no | — | — | propagate + report (AFIP cambió formato) |
+| `AuthorizeAdapter::FecaeSolicitarResultParser` | no | — | — | propagate + report (capa crítica: revisar `response` cruda) |
+| `…FecaeResponseParser` / `…ObservationParser` / `…ErrorParser` / `…EventsParser` | no | — | — | log/acumular en `errors` (no fatal: el CAE ya pudo parsearse) |
+| `Bill::MissingAttributes` / `Bill::InvalidValueAttribute` | no | — | — | log en `bill.errors` (validación local, corregir input) |
+
+Notas:
+- `report` = candidato a Sentry/exis_ray (observabilidad = otra capa).
+- Tras `ServerTimeout`/`ClientError` en `authorize!`, **nunca** reintentar a ciegas: el comprobante pudo haberse emitido en AFIP (ver `docs/consumed/afip.md §c`).
+- `inferred`: la criticidad/acción la deduje del diseño "No Explota" + flujo; el humano confirma la política operacional real.
+
+## 2.d Shape del payload de error
+
+No hay payload serializado (no es servicio). Las formas que cruzan la frontera:
+
+- **Excepción Ruby**: `message` + `backtrace` (la base guarda `backtrace` en `attr_accessor`).
+- **`bill.errors`**: `Hash` `{ attr_symbol => [String mensajes] }` (validación).
+- **`authorize_adapter.errors`**: colección de excepciones de parseo no-fatales.
+- **`afip_errors` / `afip_events` / `afip_observations`**: `Hash` `{ code => msg }` con lo devuelto por AFIP.
+
+## 3. Inferencias
+
+| ítem | confidence | a verificar |
+|---|---|---|
+| `ServerTimeout < Timeout::Error` (no `< Snoopy::Exception::Exception`) | declared | un `rescue Snoopy::Exception::Exception` **no** atrapa timeouts — confirmar si es intencional |
+| `authorize_adapter.rb:182` referencia `Snoopy::Exception::FecompConsultResponseParser` pero la clase definida es `…::AuthorizeAdapter::FecompConsultResponseParser` | declared | el `raise` levantaría `NameError` en ese path — posible bug latente (código existente, no tocar sin decisión) |
+| `errors <<` en varios `parse_*` rescue trata `errors` como Array, pero se inicializa `{}` (Hash) | declared | `Hash#<<` no existe → `NoMethodError` en ese rescue — posible bug latente |
+
+## 4. Cobertura y fronteras
+
+- Solo errores **públicos** (cruzan la frontera de la gema). Rescates internos no listados.
+- Errores del proveedor AFIP que consumimos → su mapeo en `docs/consumed/afip.md §d`.
+- Política de retry/acción → `docs/errors` §c, lo completa arch-enrich.

--- a/docs/glossary/glossary.md
+++ b/docs/glossary/glossary.md
@@ -1,0 +1,74 @@
+# Glosario — snoopy_afip
+> meta: artefacto · RFC-009 · generado arch-enrich · anclado a 7813cf2 · cobertura: términos de dominio AFIP materializados en `lib/`; parcial, acreta por PR
+
+Bounded context: facturación electrónica AFIP (Argentina). Sin capa de datos (`docs/data/` n/a) → binding a símbolo público estable (ISO 11179), no a tabla.
+
+## WSAA
+
+Web Service de Autenticación y Autorización de AFIP. Recibe un CMS firmado (cert + clave privada) y devuelve `token` + `sign` válidos 12h (la gema pide `to = from + 12h`). Es el prerrequisito para operar contra WSFE.
+
+**Binding:** `Snoopy::AuthenticationAdapter` (`authentication_adapter.rb`); operación `:login_cms`.
+
+## WSFE
+
+Web Service de Facturación Electrónica v1 de AFIP. Autoriza comprobantes y devuelve el CAE. Requiere las credenciales de WSAA en cada request (`Auth`).
+
+**Binding:** `Snoopy::AuthorizeAdapter` (`authorize_adapter.rb`); operaciones `:fecae_solicitar`, `:fe_comp_ultimo_autorizado`, `:fe_comp_consultar`.
+
+## CAE (Código de Autorización Electrónico)
+
+Código que AFIP otorga al aprobar un comprobante; sin CAE la factura no es válida. Viene con fecha de vencimiento (`cae_fch_vto`).
+
+**Binding:** `Bill#cae`, `Bill#due_date_cae`; seteados en `AuthorizeAdapter#parse_fecae_solicitar_response`.
+
+## CMS / TRA
+
+**TRA** (Ticket de Requerimiento de Acceso): XML `loginTicketRequest` con `uniqueId`, `generationTime`, `expirationTime` y `service=wsfe`. **CMS**: el TRA firmado en PKCS7 (cert + pkey), base64, que se manda a WSAA.
+
+**Binding:** `AuthenticationAdapter#build_tra` (TRA), `#build_cms` (CMS).
+
+## cbte_type (tipo de comprobante)
+
+Código AFIP del tipo de comprobante (Factura A/B/C, Nota de Crédito A/B/C). En la gema se **deriva** de la condición IVA del receptor (`receiver_iva_cond`), no se pasa directo.
+
+**Binding:** `Bill#cbte_type` → `Snoopy::BILL_TYPE[receiver_iva_cond]`; tabla completa en `Snoopy::CBTE_TYPE`.
+
+## alicivas (alícuotas de IVA)
+
+Discriminación de IVA por ítem del comprobante: array de hashes `{id, amount, taxeable_base}` donde `id` es el porcentaje de IVA (0.105, 0.21, 0.27…) mapeado al código AFIP. Monotributistas no las informan.
+
+**Binding:** `Bill#alicivas`, `Bill::TAX_ATTRIBUTES`; código AFIP en `Snoopy::ALIC_IVA`; armado en `AuthorizeAdapter#build_body_request` (clave `Iva`).
+
+## Condición IVA — emisor vs receptor
+
+Tres conceptos distintos conviven:
+- **`issuer_iva_cond`** (emisor): determina si se informan alícuotas (monotributo no). Valores en `Snoopy::IVA_COND`.
+- **`receiver_iva_cond`** (receptor): determina el `cbte_type` (clave de `Snoopy::BILL_TYPE`).
+- **`receiver_iva_condition`** (RG 5616, "verdadera condición IVA del receptor"): id que AFIP exige en el detalle (`CondicionIVAReceptorId`). Valores en `Snoopy::IVA_COND_RECEIVER`.
+
+**Binding:** `Bill#issuer_iva_cond`, `#receiver_iva_cond`, `#receiver_iva_condition` / `#receiver_iva_condition_id`.
+
+## Resultado (A / P / R)
+
+Veredicto de AFIP sobre el comprobante: `A` aprobado, `P` aprobado parcial, `R` rechazado.
+
+**Binding:** `Bill#result`, `#approved?`, `#partial_approved?`, `#rejected?`.
+
+## afip_errors / afip_events / afip_observations
+
+Tres canales que AFIP devuelve en la respuesta, parseados en hashes `code => msg` separados. **Errores**: motivos de rechazo. **Eventos**: avisos de AFIP (ej. cambios futuros). **Observaciones**: motivos por los que no se autorizó. No son excepciones Ruby — el flujo no explota (ver `docs/behavior/`).
+
+**Binding:** `AuthorizeAdapter#afip_errors/#afip_events/#afip_observations`.
+
+## 3. Inferencias
+
+| término | confidence | nota |
+|---|---|---|
+| `receiver_iva_condition` (RG 5616) | inferred | el comentario del código dice "la verdadera condición de iva del receptor"; confirmar nombre de negocio exacto |
+| Candidato canónico (RFC-019) | inferred | `CAE`, `WSFE`, `condición IVA` probablemente aparecen en otros repos de facturación del fleet → candidatos a glosario canónico; arch-enrich no lo crea, lo flaggea |
+
+## 4. Cobertura y fronteras
+
+- Términos materializados en `lib/` actual. Acreta por PR.
+- Sin `Binding:` a tabla (gema sin datos); binding a símbolo público.
+- Significado de negocio profundo (reglas AFIP) fuera de alcance: referencia al manual del desarrollador AFIP (ver `docs/consumed/afip.md`).

--- a/docs/interface/interface.md
+++ b/docs/interface/interface.md
@@ -1,0 +1,86 @@
+# Interfaz — snoopy_afip
+> meta: artefacto · RFC-004 · generado arch-structure · anclado a 7813cf2 · cobertura: superficie pública de `lib/snoopy_afip/`
+
+## 1. Resumen
+
+API Ruby pública de la gema. Módulo raíz `Snoopy` (configuración global + helpers) y cuatro clases de dominio: `AuthenticationAdapter` (WSAA), `AuthorizeAdapter` (WSFE), `Bill` (comprobante), `Client` (wrapper Savon). Constantes de dominio en `Snoopy::*` y jerarquía de errores en `Snoopy::Exception::*`.
+
+## 2. Símbolos públicos
+
+| símbolo | tipo | nota |
+|---|---|---|
+| `Snoopy` | module | raíz; `extend self`; config global vía `attr_accessor` |
+| `Snoopy.cuit` `=` | accessor | CUIT del emisor |
+| `Snoopy.sale_point` `=` | accessor | punto de venta |
+| `Snoopy.service_url` `=` | accessor | WSDL de WSFE |
+| `Snoopy.auth_url` `=` | accessor | WSDL de WSAA |
+| `Snoopy.pkey` `=` | accessor | path/contenido de clave privada |
+| `Snoopy.cert` `=` | accessor | path/contenido de certificado |
+| `Snoopy.default_document_type` `=` | accessor | default de `Bill#document_type` |
+| `Snoopy.default_concept` `=` | accessor | default de `Bill#concept` |
+| `Snoopy.default_currency` `=` | accessor | default de `Bill#currency` |
+| `Snoopy.own_iva_cond` `=` | accessor | condición IVA propia |
+| `Snoopy.verbose` `=` | accessor | flag de verbosidad (Savon) |
+| `Snoopy.open_timeout` `=` | accessor | timeout de apertura; default `30` |
+| `Snoopy.read_timeout` `=` | accessor | timeout de lectura; default `30` |
+| `Snoopy.auth_hash` | method | `{"Token"=>…, "Sign"=>…, "Cuit"=>…}` — ver §3 |
+| `Snoopy.bill_types` | method | array `[etiqueta, código]` de tipos habilitados |
+| `Snoopy::Client` | class | wrapper de `Savon.client` |
+| `Snoopy::Client#initialize(attrs)` | method | `attrs` → opciones Savon |
+| `Snoopy::Client#call(service, args={})` | method | invoca SOAP con `Timeout`; devuelve `.body`; traduce fallos a `ServerTimeout`/`ClientError` |
+| `Snoopy::Client#savon` `=` | accessor | cliente Savon subyacente |
+| `Snoopy::AuthenticationAdapter` | class | flujo WSAA |
+| `…#initialize(attrs={})` | method | `attrs[:pkey]`, `attrs[:cert]` |
+| `…#authenticate!` | method | invoca `:login_cms`; devuelve hash con `:token`, `:sign`, `:expiration_time` |
+| `…#build_tra` | method | arma el TRA (XML) para `wsfe` |
+| `…#build_cms` | method | firma el TRA en PKCS7 → CMS base64 |
+| `….generate_pkey(leng=8192)` | class method | genera clave privada RSA PEM |
+| `….generate_certificate_request_with_ruby(pkey, subj_o, subj_cn, subj_cuit)` | class method | CSR vía OpenSSL Ruby |
+| `….generate_certificate_request_with_bash(pkey, subj_o, subj_cn, subj_cuit)` | class method | CSR vía `openssl req` (shell) |
+| `Snoopy::AuthorizeAdapter` | class | flujo WSFE |
+| `…#initialize(attrs)` | method | `:bill, :cuit, :sign, :pkey, :cert, :token` |
+| `…#authorize!` | method | invoca `:fecae_solicitar`; setea CAE/result en `bill`; devuelve bool |
+| `…#set_bill_number!` | method | invoca `:fe_comp_ultimo_autorizado`; setea `bill.number` |
+| `…#invoice_informed?` | method | invoca `:fe_comp_consultar`; devuelve bool |
+| `…#auth` | method | `{"Token"=>…, "Sign"=>…, "Cuit"=>…}` de la instancia |
+| `…#errors` `=` | accessor | errores internos de parseo (hash de excepciones) |
+| `…#afip_errors` `=` | accessor | errores devueltos por AFIP (`code=>msg`) |
+| `…#afip_events` `=` | accessor | eventos devueltos por AFIP |
+| `…#afip_observations` `=` | accessor | observaciones devueltas por AFIP |
+| `…#request` `=` / `#response` `=` | accessor | payload enviado / respuesta cruda |
+| `Snoopy::Bill` | class | modela el comprobante |
+| `…#initialize(attrs={})` | method | ver §4 README para `attrs` |
+| `…#valid?` | method | corre validaciones; puebla `#errors` |
+| `…#errors` `=` | accessor | hash `attr => [mensajes]` |
+| `…#total` | method | neto + IVA, redondeado 2 |
+| `…#iva_sum` | method | suma de `amount` de `alicivas` |
+| `…#cbte_type` | method | código de comprobante según `receiver_iva_cond` |
+| `…#cbte_asoc_type` | method | código del comprobante asociado |
+| `…#receiver_iva_condition_id` | method | id de condición IVA del receptor (RG 5616) |
+| `…#exchange_rate` | method | `1` si `:peso`; resto sin implementar (ver §3) |
+| `…#approved?` / `#rejected?` / `#partial_approved?` | method | estado del resultado AFIP (`A`/`R`/`P`) |
+| `…#to_h` / `#to_hash` | method | volcado de instance vars |
+| `Snoopy::Bill::ATTRIBUTES` | const | lista de `attr_accessor` del comprobante |
+| `Snoopy::Bill::TAX_ATTRIBUTES` | const | `[:id, :amount, :taxeable_base]` |
+| `Snoopy::Bill::ATTRIBUTES_PRECENSE` | const | atributos requeridos en validación |
+| `Snoopy::CBTE_TYPE` `Snoopy::BILL_TYPE` `Snoopy::CONCEPTS` `Snoopy::DOCUMENTS` `Snoopy::CURRENCY` `Snoopy::ALIC_IVA` `Snoopy::IVA_COND` `Snoopy::IVA_COND_RECEIVER` | const | tablas de dominio (ver `docs/data/` n/a → enriquecer en glosario) |
+| `Snoopy::RESPONSABLE_INSCRIPTO` `…_MONOTRIBUTO` `CONSUMIDOR_FINAL` `IVA_SUJETO_EXENTO` `IVA_NO_ALCANZADO` | const | símbolos de condición IVA |
+| `Snoopy::SNOOPY_SSL_VERSION` | const | versión TLS (de `ENV['SNOOPY_SSL_VERSION']`, default `:TLSv1`) — ver `docs/config/` |
+| `Snoopy::Exception::*` | module/class | jerarquía de errores — ver `docs/errors/` |
+| `String#underscore` `Hash#symbolize_keys[!]` `Hash#deep_symbolize_keys` `Hash#underscore_keys[!]` `Float#round_with_precision` `Float#round_up_with_precision` | core_ext | **monkey-patches globales** sobre `String`/`Hash`/`Float` — contaminan el host (ver §4) |
+
+## 3. Inferencias
+
+| ítem | confidence | a verificar |
+|---|---|---|
+| `Bill#exchange_rate` solo resuelve `:peso` (`return 1`); el resto del método está comentado → devuelve `nil` para moneda extranjera | declared | confirmar si es intencional o feature incompleta |
+| `Snoopy.auth_hash` usa `Snoopy::TOKEN` / `Snoopy::SIGN` (constantes **no definidas** en el código leído) | declared | `auth_hash` levantaría `NameError`; `AuthorizeAdapter#auth` es la vía viva — confirmar si `auth_hash` es legacy muerto |
+| `core_ext` define métodos solo `unless method_defined?` (Hash/String) pero `Float` y `String#underscore` se redefinen siempre | declared | colisión potencial con ActiveSupport en hosts Rails |
+
+## 4. Cobertura y fronteras
+
+- **Significado de negocio** de constantes/atributos → fuera de alcance (va a `docs/glossary/`, arch-enrich).
+- **Errores** detallados → `docs/errors/` (RFC-020).
+- **Config runtime** (`ENV`, accessors) → `docs/config/` (RFC-012).
+- **core_ext globales**: la gema parchea `String`/`Hash`/`Float` del host — superficie pública de facto aunque no sea el API previsto; el impacto (colisión con ActiveSupport) es concern de comportamiento → arch-enrich.
+- `Snoopy::Exception::ServerTimeout < Timeout::Error` (no hereda de `Snoopy::Exception::Exception`) — detalle en `docs/errors/`.

--- a/docs/test/testing.md
+++ b/docs/test/testing.md
@@ -1,0 +1,75 @@
+# Test — snoopy_afip
+> meta: artefacto · RFC-013 · generado arch-structure · enriquecido arch-enrich · anclado a 7813cf2 · cobertura: inventario estructural; §e-§h 4/4
+
+## 1. Resumen
+
+Suite RSpec en `spec/`. **Estado crítico**: los specs actuales están **desactualizados respecto al código** — referencian una API que ya no existe (`Snoopy::Bill.header`, `Snoopy::Authorizer`, `Snoopy::NullOrInvalidAttribute`, `@bill.net`, `@bill.authorize`, `Snoopy.default_moneda`) y `spec_helper.rb` hace `require 'snoopy'` (el archivo es `snoopy_afip`). No corren verde contra `lib/` actual.
+
+## 2.a Suites, frameworks y niveles
+
+| framework | subdirectorio | propósito | nivel | tags |
+|---|---|---|---|---|
+| RSpec | `spec/snoopy_afip/bill_spec.rb` | comportamiento de `Bill` (header, cbte_type, iva_sum, autorización) | unit/integration | — |
+| RSpec | `spec/snoopy_afip/authorizer_spec.rb` | lectura de credenciales en init | unit | — |
+| RSpec | `spec/spec_helper.rb` | bootstrap + config global de prueba | — | — |
+
+## 2.b Comando de corrida
+
+```bash
+bundle exec rspec
+```
+
+No hay CI declarado (sin `.github/workflows/`, `.circleci/`, `bin/ci`, `config/ci.rb`). Corrida solo local.
+
+## 2.c Fixtures / Factories
+
+- Fixtures por path en `spec_helper.rb`: `Snoopy.pkey = "spec/fixtures/pkey"`, `Snoopy.cert = "spec/fixtures/cert.crt"`. **El directorio `spec/fixtures/` no está versionado** (no aparece en `git ls-files`) → los specs no tienen sus fixtures.
+- Sin FactoryBot; sin `spec/support/` versionado (el `Dir[...support...]` no matchea nada).
+- `ENV["CUIT"]` requerida por `spec_helper.rb:16` (usar valor de prueba, nunca CUIT real).
+- URLs de **homologación** AFIP (`wsaahomo`/`wswhomo`) cableadas en el helper.
+
+## 2.d Configuración de coverage
+
+Ninguna (sin `.simplecov` / `SimpleCov.start`). Sin umbral declarado.
+
+## 2.e Gaps de cobertura
+
+**Cobertura real efectiva: ~0%.** Los specs no corren contra el código actual (API divergente). Flujos de negocio **sin cobertura ejecutable**:
+- Autenticación WSAA (`authenticate!`, `build_cms`/`build_tra`) — no testeado.
+- Autorización WSFE (`authorize!`, `build_body_request`) — el spec viejo lo intentaba pero contra API inexistente.
+- Parseo en capas de la respuesta AFIP (`parse_*`) — no testeado; es la lógica más frágil (depende del formato de AFIP).
+- Validaciones de `Bill#valid?` — el spec viejo no las cubre.
+- `core_ext` (round_with_precision, deep_symbolize_keys) — no testeado.
+
+## 2.f Contract-assessment
+
+| contrato público | test? |
+|---|---|
+| operaciones (RFC-003) | n/a (gema sin superficie) |
+| dependencias consumidas WSAA/WSFE (RFC-018) | **no** — sin mocks de Savon ni VCR; ninguna llamada AFIP ejercitada |
+| errores públicos (RFC-020) | **no** — jerarquía `Snoopy::Exception::*` sin tests |
+
+Ningún contrato público está cubierto. Riesgo alto: un cambio de formato de AFIP no lo detecta ningún test.
+
+## 2.g Link a incidente
+
+Ninguno declarado. El diseño "No Explota" (parseo en capas, README §) nació de un incidente real (AFIP cambió la estructura de eventos y "explotaba todo") — narrado en el README pero **sin test de regresión** que lo fije.
+
+## 2.h PII en fixtures
+
+- `spec_helper.rb` referencia `spec/fixtures/pkey` y `spec/fixtures/cert.crt` (**no versionados**). Si se agregan, serían **clave privada + certificado AFIP = secretos**: nunca commitear reales; usar material de homologación descartable.
+- `ENV["CUIT"]`: usar CUIT de prueba, nunca uno real (es dato identificatorio).
+- Sin otros fixtures con PII detectados.
+
+## 3. Inferencias
+
+| ítem | confidence | a verificar |
+|---|---|---|
+| Specs no ejecutables contra el código actual (API divergente + `require` roto + fixtures ausentes) | declared | la suite es legacy pre-refactor; decidir reescritura o baja |
+| `Gemfile` incluye `ruby-debug` (`require 'ruby-debug'` en helper) | inferred | dep de test posiblemente incompatible con Ruby moderno |
+
+## 4. Cobertura y fronteras
+
+- El contenido detallado de cada test queda en el código.
+- Evaluación de gaps/contract/PII → arch-enrich (§e-§h).
+- La divergencia specs↔código es el hallazgo dominante de esta capa: bloquea cualquier afirmación de cobertura real.

--- a/docs/topology/topology.md
+++ b/docs/topology/topology.md
@@ -1,0 +1,44 @@
+# Topología — snoopy_afip
+> meta: artefacto · RFC-006 · generado arch-structure · anclado a 7813cf2 · cobertura: deps de runtime + servicios externos AFIP
+
+## 1. Resumen
+
+Gema cliente SOAP. Una sola dependencia de runtime declarada en el `.gemspec` (`savon`), que arrastra el stack SOAP (httpi, nori, gyoku, akami, wasabi, nokogiri). Consume dos servicios SOAP externos de AFIP: WSAA (auth) y WSFE (facturación). No corre como proceso propio: se embebe en el host (típicamente una app Rails).
+
+## 2. Dependencias
+
+| nombre | versión | rol |
+|---|---|---|
+| `savon` | `~> 2.12.1` (gemspec) · `2.12.0` (lock) | cliente SOAP — única dep de runtime declarada |
+| `httpi` | `2.4.4` (lock, transitiva) | capa HTTP de savon |
+| `nori` | `2.6.0` (lock, transitiva) | XML→Hash (usado directo en `AuthenticationAdapter`) |
+| `nokogiri` | `1.10.9` (lock, transitiva) | parser XML; usado directo en `build_tra` (`Nokogiri::XML::Builder`) |
+| `gyoku` `akami` `wasabi` `builder` `rack` `socksify` `mini_portile2` | ver lock | transitivas de savon |
+| `OpenSSL` (stdlib) | — | firma CMS/PKCS7, generación de clave/CSR |
+| `Timeout` (stdlib) | — | corta llamadas SOAP (`Snoopy::Client#call`) |
+
+## 3. Grafo
+
+```mermaid
+flowchart LR
+  Host["App host (Rails)"] -->|require| Snoopy["snoopy_afip"]
+  Snoopy -->|Savon.client| Savon["savon (SOAP)"]
+  Savon -->|HTTP/SOAP| WSAA["AFIP WSAA<br>login_cms"]
+  Savon -->|HTTP/SOAP| WSFE["AFIP WSFE<br>fecae_solicitar / fe_comp_*"]
+  Snoopy -->|firma CMS| OpenSSL["OpenSSL (stdlib)"]
+  Snoopy -->|build_tra| Nokogiri["nokogiri"]
+  Snoopy -->|parse| Nori["nori"]
+```
+
+## 4. Modos de ejecución
+
+| modo | aplica | nota |
+|---|---|---|
+| librería embebida | sí | se usa dentro del proceso del host; sin daemon/worker propio |
+| web / worker / cron propios | no | la gema no define procesos |
+
+## 5. Cobertura y fronteras
+
+- **`Gemfile.lock` divergente** (ver `docs/test/` y nota global): el lock fija `snoopy_afip (4.0.1)` mientras `version.rb` dice `4.3.0`, y lista en `PATH specs` deps (`akami`, `nokogiri`, `nori`, `wasabi`) que el `.gemspec` **actual** no declara explícitamente (solo `savon`). El lock parece no regenerado tras cambios de gemspec/versión. Versiones de la tabla tomadas del lock como mejor evidencia disponible, marcadas.
+- Servicios AFIP externos (WSAA/WSFE): contrato consumido en `docs/consumed/` (RFC-018).
+- Topología upstream de AFIP (infra del organismo) fuera de alcance.

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: snoopy-afip
+description: >
+  Gema Ruby `snoopy_afip` — adaptador de Facturación Electrónica de AFIP
+  (Argentina). Resuelve los servicios SOAP WSAA (autenticación: token/sign a
+  partir de cert+pkey) y WSFE (autorización de comprobantes: devuelve CAE) vía
+  `savon`. Activá esta skill cuando trabajes con emisión de facturas/notas de
+  crédito electrónicas argentinas, autenticación contra AFIP, el módulo
+  `Snoopy`, o las clases `AuthenticationAdapter` / `AuthorizeAdapter` / `Bill`.
+triggers:
+  - "facturación electrónica AFIP"
+  - "emitir factura electrónica argentina"
+  - "autenticar contra WSAA"
+  - "autorizar comprobante WSFE"
+  - "obtener CAE de AFIP"
+  - "usar la gema snoopy_afip"
+  - "Snoopy::AuthorizeAdapter / Snoopy::Bill"
+---
+
+# snoopy_afip — skill de agente
+
+Contrato resumido de la gema. El detalle vive en `docs/<capa>/` (anclado a `4.3.0` / commit `7813cf2`); esta skill indexa y resume.
+
+## Qué es / cuándo usar
+
+Adaptador de la Facturación Electrónica de AFIP. Úsala para autenticar (WSAA) y autorizar comprobantes (WSFE) desde Ruby. Se configura en el host vía `Snoopy.<attr> = …` y se opera con tres clases. No corre como proceso propio: es librería embebida.
+
+## Contrato resumido (piso mínimo)
+
+**Flujo típico** (autenticar → numerar → autorizar):
+
+```ruby
+auth = Snoopy::AuthenticationAdapter.new(pkey: pkey, cert: cert)
+creds = auth.authenticate!                      # {token, sign, expiration_time} (12h)
+
+bill = Snoopy::Bill.new(cuit:, sale_point:, concept:, document_type:, document_num:,
+                        issuer_iva_cond:, receiver_iva_cond:, receiver_iva_condition:,
+                        total_net:, alicivas:)   # alicivas: [{id:, amount:, taxeable_base:}]
+adapter = Snoopy::AuthorizeAdapter.new(bill:, pkey:, cert:, cuit:,
+                                       token: creds[:token], sign: creds[:sign])
+adapter.set_bill_number!                         # último autorizado + 1
+adapter.authorize!                               # setea bill.cae / bill.result
+```
+
+**Símbolos clave:** `Snoopy` (config global), `Snoopy::AuthenticationAdapter` (WSAA), `Snoopy::AuthorizeAdapter` (WSFE), `Snoopy::Bill` (comprobante), `Snoopy::Client` (wrapper Savon). Tablas de dominio: `Snoopy::BILL_TYPE`, `ALIC_IVA`, `IVA_COND_RECEIVER`, `DOCUMENTS`, `CURRENCY`.
+
+**Gotchas (load-bearing):**
+- `receiver_iva_cond` (key de `BILL_TYPE`) determina el `cbte_type` — distinto de `issuer_iva_cond` y de `receiver_iva_condition` (RG 5616). Ver glosario.
+- **Tras timeout en `authorize!` no reintentar a ciegas**: el comprobante pudo emitirse en AFIP — verificar con `invoice_informed?` (`docs/consumed/afip.md §c`).
+- AFIP exige TLS ≥1.2; el default `SNOOPY_SSL_VERSION=:TLSv1` quedó desactualizado (`docs/config/configuracion.md §f`).
+- `pkey`/`cert`/`cuit` son secretos: setear en el host, nunca commitear.
+- La gema **parchea globalmente** `String`/`Hash`/`Float` (core_ext) — posible colisión con ActiveSupport.
+
+## Índice de artefactos
+
+| capa | path | nota |
+|---|---|---|
+| interfaz | [`docs/interface/interface.md`](../docs/interface/interface.md) | API Ruby pública |
+| comportamiento | [`docs/behavior/behavior.md`](../docs/behavior/behavior.md) | secuencias WSAA/WSFE |
+| glosario | [`docs/glossary/glossary.md`](../docs/glossary/glossary.md) | términos AFIP |
+| consumidas | [`docs/consumed/afip.md`](../docs/consumed/afip.md) | SOAP WSAA + WSFE |
+| errores | [`docs/errors/errors.md`](../docs/errors/errors.md) | excepciones + política |
+| configuración | [`docs/config/configuracion.md`](../docs/config/configuracion.md) | opciones runtime |
+| topología | [`docs/topology/topology.md`](../docs/topology/topology.md) | deps + externos |
+| test | [`docs/test/testing.md`](../docs/test/testing.md) | suite + gaps |
+| operaciones (api) · datos · eventos · multi-tenancy | n/a | gema SOAP sin HTTP/DB/eventos |
+
+## Uso correcto / gotchas
+
+- Homologación vs producción se elige por `auth_url`/`service_url` — riesgo de emitir contra prod por error.
+- Errores de negocio de AFIP **no** levantan excepción: se leen en `afip_errors`/`afip_events`/`afip_observations`.
+- La suite RSpec actual está desactualizada respecto al código (ver `docs/test/testing.md`) — no asumir cobertura.

--- a/skills.yml
+++ b/skills.yml
@@ -1,0 +1,17 @@
+mcps:
+  - github
+  - clickup
+skills:
+  multi-vendor-feedback:
+  yard:
+  quality-code:
+  gem-release:
+  arch-structure:
+  arch-compose:
+  arch-enrich:
+  skill-feedback:
+  agent-issue:
+  bug-report:
+  dev-flow:
+  documentation-writer:
+  matrix-element:


### PR DESCRIPTION
## Qué

Regeneración completa del grafo de artefactos de arquitectura de la gema (RFC-002..020) + normalización de `skills.yml`/`AGENTS.md`/`CLAUDE.md` (commit previo).

### Grafo `docs/<capa>/` (nuevo)
- **Estructura** (arch-structure): `interface`, `topology`, `consumed/afip`, `errors`, `config`, `test`
- **Enriquecimiento** (arch-enrich): `glossary`, `behavior` + §c/§e consumed, §c errors, §f config, §e-§h test
- **Compuestos** (arch-compose): `skill/SKILL.md` (RFC-008), `README.md` rehecho (RFC-010), Mapa de conocimiento en `AGENTS.md`

### README rehecho
El README legacy traía un **token WSAA de homologación expirado (2017)** en el ejemplo. El nuevo lo elimina y usa placeholders para `pkey`/`cert`/`cuit`. Uso anclado al API actual (el legacy referenciaba símbolos inexistentes).

## Verificación
- `critias --full`: **0 errores** (3 warnings corregidos: §e duplicado en consumed, filename `test.md`→`testing.md`).
- `docs/` y `skill/` se empaquetan en el `.gem` (gemspec usa `git ls-files`) → version-lock.

## Hallazgos documentados (no corregidos)
Marcados `inferred` en `docs/errors/errors.md §3` — bugs latentes en código existente (decisión aparte si se abren issues):
- `ServerTimeout` no hereda de la base `Snoopy::Exception::Exception`
- `FecompConsultResponseParser` mal referenciado (`authorize_adapter.rb:182`)
- `errors <<` sobre `Hash` en rescues de parseo
- `Gemfile.lock` stale (4.0.1 vs 4.3.0); specs RSpec no ejecutables

🤖 Generated with [Claude Code](https://claude.com/claude-code)