### PR TITLE
fix: eliminar Snoopy.auth_hash (código muerto, NameError) (#12)

### DIFF
--- a/lib/snoopy_afip.rb
+++ b/lib/snoopy_afip.rb
@@ -23,10 +23,6 @@ module Snoopy
   self.open_timeout ||= 30
   self.read_timeout ||= 30
 
-  def auth_hash
-    {"Token" => Snoopy::TOKEN, "Sign"  => Snoopy::SIGN, "Cuit"  => Snoopy.cuit}
-  end
-
   def bill_types
     [
       ["Factura A", "01"],


### PR DESCRIPTION
Closes #12

## Cambio

`Snoopy.auth_hash` (`lib/snoopy_afip.rb`) referenciaba `Snoopy::TOKEN` y `Snoopy::SIGN`, constantes inexistentes en la gema → cualquier llamada levantaba `NameError`.

```diff
-  def auth_hash
-    {"Token" => Snoopy::TOKEN, "Sign"  => Snoopy::SIGN, "Cuit"  => Snoopy.cuit}
-  end
```

Sin consumidores (`grep auth_hash` en `lib/` y `spec/` = solo la definición). La vía viva de credenciales es `Snoopy::AuthorizeAdapter#auth`, que usa los atributos de instancia `token`/`sign`/`cuit`.

## Nota de API

Es la remoción de un método público a nivel módulo, pero estaba **roto** (siempre fallaba), así que ningún consumidor real podía depender de él funcionando.

## Verificación

- `ruby -c` OK. Suite runtime bloqueada por #13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)