### PR TITLE
chore: higiene del gemspec (date auto, required_ruby_version)

### DIFF
--- a/snoopy_afip.gemspec
+++ b/snoopy_afip.gemspec
@@ -7,9 +7,8 @@ Gem::Specification.new do |s|
   s.name = "snoopy_afip"
   s.version = Snoopy::VERSION
 
-  s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
+  s.required_ruby_version = ">= 2.5"
   s.authors = ["g.edera"]
-  s.date = "2017-06-29"
   s.description = "Adaptador para Web Service de Facturación Electrónica Argentina (AFIP)"
   s.email = "gab.edera@gmail.com"
   s.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }


### PR DESCRIPTION
## Cambio

Higiene del gemspec, **sin cambios de dependencias ni de comportamiento**.

```diff
-  s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
+  s.required_ruby_version = ">= 2.5"
   s.authors = ["g.edera"]
-  s.date = "2017-06-29"
   s.description = "Adaptador para Web Service de Facturación Electrónica Argentina (AFIP)"
```

- **Quita `s.date = "2017-06-29"`** hardcodeada → rubygems la setea automáticamente al build.
- **Quita `required_rubygems_version = ">= 0"`** — no-op (`>= 0` siempre verdadero).
- **Agrega `required_ruby_version = ">= 2.5"`** — piso conservador (el código usa safe-navigation `&.`, soportado desde 2.3; 2.5 es un floor moderno no-breaking). El piso real se firmará con el upgrade de savon.

## Validación

- `gem build` OK (spec válido, v4.3.0).
- `Gem::Specification.load` confirma: `required_ruby_version >= 2.5`, date auto, dep `savon ~> 2.12.1` intacta.

## Fuera de alcance (gated en #13)

El **upgrade de savon/nokogiri** NO va en este PR. El stack actual (nokogiri 1.10.9, 2020) tiene CVEs y no compila en Ruby 3.4 — pero savon 2.15+ salta httpi 2→4 y wasabi 3→5, cambiando el transporte SSL/mTLS contra AFIP. Eso requiere tests verdes (#13) y validación contra homologación antes de tocarlo. Este PR es solo la higiene segura.

🤖 Generated with [Claude Code](https://claude.com/claude-code)