### PR TITLE
test: reescribir suite RSpec + regenerar Gemfile.lock (#13)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,9 @@ Framework: **RSpec** (verificado en `spec/spec_helper.rb` con `require 'rspec'` 
 bundle exec rspec
 ```
 
-El código nuevo debe venir con tests. Specs actuales: `spec/snoopy_afip/bill_spec.rb`, `spec/snoopy_afip/authorizer_spec.rb`. `spec/spec_helper.rb` requiere una variable de entorno `CUIT` (usar valores de prueba, nunca CUIT/credenciales reales).
+El código nuevo debe venir con tests. La suite (`spec/snoopy_afip/{bill,authorize_adapter,authentication_adapter,exceptions}_spec.rb`) son unit puros, sin fixtures ni llamadas reales a AFIP; usar placeholders, nunca CUIT/credenciales reales.
+
+**Runtime: la suite corre bajo Ruby 2.7.x** (runtime del consumidor). En Ruby 3.x la gema **no carga** — el stack de savon 2.12 (httpi 2.x) depende de `kconv` y `Rack::Utils::HeaderHash`, removidos en Ruby 3.x / rack 3. Correr en 3.x requiere el upgrade de savon a 2.15+ (ver `docs/test/testing.md`). El `Gemfile.lock` está resuelto para 2.7.
 
 ## 7. Releases
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,10 @@
 source "http://rubygems.org"
 
 gemspec
+
+# httpi 2.x (vía savon 2.12) usa Rack::Utils::HeaderHash, removido en rack 3.
+# Pin de entorno de test; el consumidor Rails trae su propio rack 2.x.
+gem "rack", "~> 2.2"
 # group :development do
 #   platforms :ruby_18 do
 #     gem "ruby-debug"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,31 +1,70 @@
 PATH
   remote: .
   specs:
-    snoopy_afip (4.0.1)
-      akami (~> 1.3.1)
-      nokogiri (~> 1.10.9)
-      nori (~> 2.6.0)
-      savon (~> 2.12.0)
-      wasabi (~> 3.5.0)
+    snoopy_afip (4.3.0)
+      savon (~> 2.12.1)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    akami (1.3.1)
+    activesupport (7.1.6)
+      base64
+      benchmark (>= 0.3)
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      logger (>= 1.4.2)
+      minitest (>= 5.1)
+      mutex_m
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0)
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
+    akami (1.3.2)
       gyoku (>= 0.4.0)
       nokogiri
-    builder (3.2.4)
-    gyoku (1.3.1)
+    base64 (0.3.0)
+    benchmark (0.5.0)
+    bigdecimal (4.1.2)
+    builder (3.3.0)
+    concurrent-ruby (1.3.7)
+    connection_pool (2.5.5)
+    diff-lcs (1.6.2)
+    drb (2.2.3)
+    gyoku (1.4.0)
       builder (>= 2.1.2)
-    httpi (2.4.4)
+      rexml (~> 3.0)
+    httpi (2.5.0)
       rack
       socksify
-    mini_portile2 (2.4.0)
-    nokogiri (1.10.9)
-      mini_portile2 (~> 2.4.0)
+    i18n (1.14.8)
+      concurrent-ruby (~> 1.0)
+    logger (1.7.0)
+    minitest (5.26.1)
+    mutex_m (0.3.0)
+    nokogiri (1.15.7-arm64-darwin)
+      racc (~> 1.4)
     nori (2.6.0)
-    rack (2.2.2)
-    savon (2.12.0)
+    public_suffix (5.1.1)
+    racc (1.8.1)
+    rack (2.2.23)
+    rexml (3.4.4)
+    rspec (3.13.2)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.6)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.5)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.8)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.7)
+    savon (2.12.1)
       akami (~> 1.2)
       builder (>= 2.1.2)
       gyoku (~> 1.2)
@@ -33,16 +72,23 @@ GEM
       nokogiri (>= 1.8.1)
       nori (~> 2.4)
       wasabi (~> 3.4)
-    socksify (1.7.1)
-    wasabi (3.5.0)
+    securerandom (0.3.2)
+    socksify (1.8.1)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    wasabi (3.7.0)
+      addressable
       httpi (~> 2.0)
       nokogiri (>= 1.4.2)
 
 PLATFORMS
-  ruby
+  arm64-darwin-24
 
 DEPENDENCIES
+  activesupport
+  rack (~> 2.2)
+  rspec (~> 3.13)
   snoopy_afip!
 
 BUNDLED WITH
-   2.1.4
+   2.4.22

--- a/docs/test/testing.md
+++ b/docs/test/testing.md
@@ -1,32 +1,33 @@
 # Test — snoopy_afip
-> meta: artefacto · RFC-013 · generado arch-structure · enriquecido arch-enrich · anclado a 7813cf2 · cobertura: inventario estructural; §e-§h 4/4
+> meta: artefacto · RFC-013 · generado arch-structure · enriquecido arch-enrich · anclado a 7813cf2 (suite reescrita en fix/specs-and-lock) · cobertura: inventario estructural; §e-§h 4/4
 
 ## 1. Resumen
 
-Suite RSpec en `spec/`. **Estado crítico**: los specs actuales están **desactualizados respecto al código** — referencian una API que ya no existe (`Snoopy::Bill.header`, `Snoopy::Authorizer`, `Snoopy::NullOrInvalidAttribute`, `@bill.net`, `@bill.authorize`, `Snoopy.default_moneda`) y `spec_helper.rb` hace `require 'snoopy'` (el archivo es `snoopy_afip`). No corren verde contra `lib/` actual.
+Suite RSpec en `spec/`, **reescrita contra la API actual y verde** (`21 examples, 0 failures`). Corre bajo **Ruby 2.7.x** (runtime del consumidor `argentina_invoice_service`). En **Ruby 3.x la gema no carga**: el stack de savon 2.12 (httpi 2.x) depende de `kconv` (removido de stdlib en 3.x) y de `Rack::Utils::HeaderHash` (removido en rack 3) → correr en 3.x requiere el upgrade de savon (gated, ver #13/roadmap).
 
 ## 2.a Suites, frameworks y niveles
 
-| framework | subdirectorio | propósito | nivel | tags |
-|---|---|---|---|---|
-| RSpec | `spec/snoopy_afip/bill_spec.rb` | comportamiento de `Bill` (header, cbte_type, iva_sum, autorización) | unit/integration | — |
-| RSpec | `spec/snoopy_afip/authorizer_spec.rb` | lectura de credenciales en init | unit | — |
-| RSpec | `spec/spec_helper.rb` | bootstrap + config global de prueba | — | — |
+| framework | archivo | propósito | nivel |
+|---|---|---|---|
+| RSpec | `spec/snoopy_afip/bill_spec.rb` | `Bill`: cbte_type, iva_sum/total, exchange_rate, receiver_iva_condition_id, estado del resultado, `valid?` | unit |
+| RSpec | `spec/snoopy_afip/authorize_adapter_spec.rb` | `AuthorizeAdapter`: `auth`, y regresión de rescues de parseo (#10/#16) | unit |
+| RSpec | `spec/snoopy_afip/authentication_adapter_spec.rb` | `AuthenticationAdapter`: `build_tra`, credenciales de instancia | unit |
+| RSpec | `spec/snoopy_afip/exceptions_spec.rb` | jerarquía `Snoopy::Exception` + paraguas `Error` (regresión #14) | unit |
+| RSpec | `spec/spec_helper.rb` | bootstrap + config base de homologación | — |
 
 ## 2.b Comando de corrida
 
 ```bash
-bundle exec rspec
+bundle exec rspec    # bajo Ruby 2.7.x
 ```
 
-No hay CI declarado (sin `.github/workflows/`, `.circleci/`, `bin/ci`, `config/ci.rb`). Corrida solo local.
+No hay CI declarado (sin `.github/workflows/`, `.circleci/`, `bin/ci`, `config/ci.rb`). Corrida solo local. Dev-deps de test: `rspec ~> 3.13`, `activesupport` (gemspec); pin `rack ~> 2.2` (Gemfile, requerido por httpi 2.x).
 
 ## 2.c Fixtures / Factories
 
-- Fixtures por path en `spec_helper.rb`: `Snoopy.pkey = "spec/fixtures/pkey"`, `Snoopy.cert = "spec/fixtures/cert.crt"`. **El directorio `spec/fixtures/` no está versionado** (no aparece en `git ls-files`) → los specs no tienen sus fixtures.
-- Sin FactoryBot; sin `spec/support/` versionado (el `Dir[...support...]` no matchea nada).
-- `ENV["CUIT"]` requerida por `spec_helper.rb:16` (usar valor de prueba, nunca CUIT real).
-- URLs de **homologación** AFIP (`wsaahomo`/`wswhomo`) cableadas en el helper.
+- **Sin fixtures en disco.** Los specs son unit puros: construyen `Bill`/adapters con placeholders inline; no requieren `spec/fixtures/pkey`/`cert.crt` ni llamadas reales a AFIP.
+- Sin FactoryBot, sin VCR. Las URLs de homologación se setean en `spec_helper.rb` pero ninguna prueba abre conexión (Savon es lazy salvo el build del cliente, que no conecta).
+- `Bill#valid?` necesita `blank?`/`present?` → `spec_helper` carga `active_support/core_ext/object/blank`.
 
 ## 2.d Configuración de coverage
 
@@ -34,42 +35,40 @@ Ninguna (sin `.simplecov` / `SimpleCov.start`). Sin umbral declarado.
 
 ## 2.e Gaps de cobertura
 
-**Cobertura real efectiva: ~0%.** Los specs no corren contra el código actual (API divergente). Flujos de negocio **sin cobertura ejecutable**:
-- Autenticación WSAA (`authenticate!`, `build_cms`/`build_tra`) — no testeado.
-- Autorización WSFE (`authorize!`, `build_body_request`) — el spec viejo lo intentaba pero contra API inexistente.
-- Parseo en capas de la respuesta AFIP (`parse_*`) — no testeado; es la lógica más frágil (depende del formato de AFIP).
-- Validaciones de `Bill#valid?` — el spec viejo no las cubre.
-- `core_ext` (round_with_precision, deep_symbolize_keys) — no testeado.
+**Cubierto** (unit, sin red): lógica de `Bill` (cálculos, validaciones, mapeos de dominio), jerarquía de excepciones + paraguas, `build_tra`, y el **comportamiento de los rescues de parseo** (no explotan, registran String).
+
+**NO cubierto** (requiere mock de Savon / VCR / homologación real):
+- `authorize!` / `set_bill_number!` / `invoice_informed?` — el camino feliz contra WSFE (no se mockea la respuesta SOAP).
+- `authenticate!` / `build_cms` — firma CMS con cert/pkey reales.
+- `parse_*` con respuestas AFIP **válidas** (solo se testea el path de error).
+- `core_ext` (`round_with_precision`, `deep_symbolize_keys`, `underscore`).
 
 ## 2.f Contract-assessment
 
 | contrato público | test? |
 |---|---|
 | operaciones (RFC-003) | n/a (gema sin superficie) |
-| dependencias consumidas WSAA/WSFE (RFC-018) | **no** — sin mocks de Savon ni VCR; ninguna llamada AFIP ejercitada |
-| errores públicos (RFC-020) | **no** — jerarquía `Snoopy::Exception::*` sin tests |
-
-Ningún contrato público está cubierto. Riesgo alto: un cambio de formato de AFIP no lo detecta ningún test.
+| dependencias consumidas WSAA/WSFE (RFC-018) | **parcial** — `build_tra` sí; las llamadas SOAP no se ejercitan (sin mock/VCR) |
+| errores públicos (RFC-020) | **sí** — jerarquía `Snoopy::Exception::*` + paraguas `Error` + comportamiento de los rescues |
 
 ## 2.g Link a incidente
 
-Ninguno declarado. El diseño "No Explota" (parseo en capas, README §) nació de un incidente real (AFIP cambió la estructura de eventos y "explotaba todo") — narrado en el README pero **sin test de regresión** que lo fije.
+- `exceptions_spec.rb` fija la jerarquía de `ServerTimeout` (regresión de **#14**).
+- `authorize_adapter_spec.rb` fija que los rescues de parseo no explotan y registran String (regresión de **#10/#16** — el diseño "No Explota" que nació de un incidente real con cambios de formato de AFIP).
 
 ## 2.h PII en fixtures
 
-- `spec_helper.rb` referencia `spec/fixtures/pkey` y `spec/fixtures/cert.crt` (**no versionados**). Si se agregan, serían **clave privada + certificado AFIP = secretos**: nunca commitear reales; usar material de homologación descartable.
-- `ENV["CUIT"]`: usar CUIT de prueba, nunca uno real (es dato identificatorio).
-- Sin otros fixtures con PII detectados.
+- Sin fixtures con PII (no hay fixtures en disco). `pkey`/`cert`/`cuit` en specs son placeholders inline (`/tmp/pkey`, `"20111111112"`), nunca material real.
 
 ## 3. Inferencias
 
 | ítem | confidence | a verificar |
 |---|---|---|
-| Specs no ejecutables contra el código actual (API divergente + `require` roto + fixtures ausentes) | declared | la suite es legacy pre-refactor; decidir reescritura o baja |
-| `Gemfile` incluye `ruby-debug` (`require 'ruby-debug'` en helper) | inferred | dep de test posiblemente incompatible con Ruby moderno |
+| La gema no carga en Ruby 3.x (kconv/httpi 2.x, Rack::Utils::HeaderHash/rack 3) | declared | desbloquea con el upgrade de savon a 2.15+ (httpi 4) — gated |
+| El lock está resuelto para Ruby 2.7 (nokogiri 1.15.7, rack 2.2) | declared | un dev en Ruby 3.x no podrá `bundle install` hasta el upgrade |
 
 ## 4. Cobertura y fronteras
 
 - El contenido detallado de cada test queda en el código.
-- Evaluación de gaps/contract/PII → arch-enrich (§e-§h).
-- La divergencia specs↔código es el hallazgo dominante de esta capa: bloquea cualquier afirmación de cobertura real.
+- Falta cobertura de los caminos felices contra AFIP (necesita mock de Savon o VCR) — próximo incremento.
+- La corrida en Ruby 3.x está bloqueada por el stack de dependencias, no por los specs.

--- a/lib/snoopy_afip/exceptions.rb
+++ b/lib/snoopy_afip/exceptions.rb
@@ -1,3 +1,5 @@
+require "timeout" # ServerTimeout < Timeout::Error; en Ruby 3.4+ timeout es default gem no autocargado
+
 module Snoopy
   module Exception
 

--- a/snoopy_afip.gemspec
+++ b/snoopy_afip.gemspec
@@ -17,7 +17,10 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   # s.rubygems_version = "1.8.25"
   s.summary = "Adaptador AFIP wsfe."
-  s.test_files = ["spec/snoopy_afip/authorizer_spec.rb", "spec/snoopy_afip/bill_spec.rb", "spec/spec_helper.rb"]
+  s.test_files = Dir["spec/**/*"]
 
   s.add_dependency 'savon', '~> 2.12.1'
+
+  s.add_development_dependency 'rspec', '~> 3.13'
+  s.add_development_dependency 'activesupport' # Bill#valid? usa blank?/present?
 end

--- a/spec/snoopy_afip/authentication_adapter_spec.rb
+++ b/spec/snoopy_afip/authentication_adapter_spec.rb
@@ -1,0 +1,20 @@
+require File.expand_path(File.dirname(__FILE__) + "/../spec_helper")
+
+RSpec.describe Snoopy::AuthenticationAdapter do
+  describe "#build_tra" do
+    it "construye el TRA (loginTicketRequest) para el servicio wsfe" do
+      xml = described_class.new.build_tra
+      expect(xml).to include("loginTicketRequest")
+      expect(xml).to include("wsfe")
+      expect(xml).to include("uniqueId")
+    end
+  end
+
+  describe "credenciales de instancia" do
+    it "expone pkey y cert recibidos" do
+      auth = described_class.new(pkey: "/tmp/pkey", cert: "/tmp/cert")
+      expect(auth.pkey).to eq("/tmp/pkey")
+      expect(auth.cert).to eq("/tmp/cert")
+    end
+  end
+end

--- a/spec/snoopy_afip/authorize_adapter_spec.rb
+++ b/spec/snoopy_afip/authorize_adapter_spec.rb
@@ -1,0 +1,37 @@
+require File.expand_path(File.dirname(__FILE__) + "/../spec_helper")
+
+RSpec.describe Snoopy::AuthorizeAdapter do
+  subject(:adapter) do
+    described_class.new(bill: nil, cuit: "20111111112", sign: "SIGN", token: "TOKEN",
+                        pkey: "/tmp/pkey", cert: "/tmp/cert")
+  end
+
+  describe "#auth" do
+    it "arma el hash de credenciales para AFIP" do
+      expect(adapter.auth).to eq("Token" => "TOKEN", "Sign" => "SIGN", "Cuit" => "20111111112")
+    end
+  end
+
+  # Regresión #10/#16: los rescues de parseo registraban con `errors << ...`
+  # sobre un Hash (NoMethodError) y la línea 182 usaba una constante mal
+  # namespaceada (NameError). Ahora registran en @errors un String (.message)
+  # y NO propagan. Se dispara pasando datos malformados (nil) a cada parser.
+  describe "rescues de parseo (no explotan)" do
+    {
+      parse_errors:       :error_parser,
+      parse_events:       :events_parser,
+      parse_observations: :observation_parser
+    }.each do |method, key|
+      it "##{method} con dato inválido registra un String en errors[#{key.inspect}] sin levantar" do
+        expect { adapter.public_send(method, nil) }.not_to raise_error
+        expect(adapter.errors[key]).to be_a(String)
+      end
+    end
+
+    it "parse_fe_comp_consultar_response con response vacío no levanta NameError" do
+      adapter.response = {}
+      expect { adapter.parse_fe_comp_consultar_response }.not_to raise_error
+      expect(adapter.errors[:fecomp_consult_response_parser]).to be_a(String)
+    end
+  end
+end

--- a/spec/snoopy_afip/authorizer_spec.rb
+++ b/spec/snoopy_afip/authorizer_spec.rb
@@ -1,9 +1,0 @@
-require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
-
-describe "Authorizer" do
-  it "should read credentials on initialize" do
-    authorizer = Snoopy::Authorizer.new
-    authorizer.pkey.should == 'spec/fixtures/pkey'
-    authorizer.cert.should == 'spec/fixtures/cert.crt'
-  end
-end

--- a/spec/snoopy_afip/bill_spec.rb
+++ b/spec/snoopy_afip/bill_spec.rb
@@ -1,106 +1,89 @@
-require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
+require File.expand_path(File.dirname(__FILE__) + "/../spec_helper")
 
-describe "Bill" do
-  it "should setup a header hash" do
-    @header = Snoopy::Bill.header(0)
-    @header.size.should == 3
-    ["CantReg", "CbteTipo", "PtoVta"].each do |key|
-      @header.has_key?(key).should == true
+RSpec.describe Snoopy::Bill do
+  def valid_attrs(overrides = {})
+    {
+      cuit:                   "20111111112",
+      sale_point:             "0001",
+      total_net:              100.0,
+      concept:                "Productos",
+      document_type:          "CUIT",
+      document_num:           "30710151543",
+      issuer_iva_cond:        Snoopy::RESPONSABLE_INSCRIPTO,
+      receiver_iva_cond:      :factura_a,
+      receiver_iva_condition: :responsable_inscripto,
+      currency:               :peso,
+      service_date_from:      "20240101",
+      service_date_to:        "20240131",
+      alicivas:               [{ id: 0.21, amount: 21.0, taxeable_base: 100.0 }]
+    }.merge(overrides)
+  end
+
+  describe "#cbte_type" do
+    it "deriva el código del comprobante desde receiver_iva_cond" do
+      expect(described_class.new(valid_attrs).cbte_type).to eq("01")          # BILL_TYPE[:factura_a]
+      expect(described_class.new(valid_attrs(receiver_iva_cond: :factura_b)).cbte_type).to eq("06")
     end
   end
 
-  describe "instance" do
-    before(:each) {@bill = Snoopy::Bill.new}
-
-    it "should initialize according to Snoopy defaults" do
-      @bill.client.class.name.should == "Savon::Client"
-      ["Token", "Sign", "Cuit"].each do |key|
-        @bill.body["Auth"][key].should_not == nil
-      end
-      @bill.documento.should == Snoopy.default_documento
-      @bill.moneda.should == Snoopy.default_moneda
+  describe "#iva_sum y #total" do
+    it "suma las alícuotas y calcula el total neto + IVA" do
+      bill = described_class.new(valid_attrs)
+      expect(bill.iva_sum).to eq(21.0)
+      expect(bill.total).to eq(121.0)
     end
 
-    it "should calculate it's cbte_tipo for Responsable Inscripto" do
-      @bill.iva_cond = :responsable_inscripto
-      @bill.cbte_type.should == "01"
+    it "total es 0 cuando el neto es 0" do
+      expect(described_class.new(valid_attrs(total_net: 0)).total).to eq(0)
+    end
+  end
+
+  describe "#exchange_rate" do
+    it "es 1 para pesos" do
+      expect(described_class.new(valid_attrs(currency: :peso)).exchange_rate).to eq(1)
+    end
+  end
+
+  describe "#receiver_iva_condition_id" do
+    it "mapea la condición de IVA del receptor (RG 5616)" do
+      expect(described_class.new(valid_attrs).receiver_iva_condition_id).to eq("1")
+      expect(described_class.new(valid_attrs(receiver_iva_condition: :consumidor_final)).receiver_iva_condition_id).to eq("5")
     end
 
-    it "should calculate it's cbte_tipo for Consumidor Final" do
-      @bill.iva_cond = :consumidor_final
-      @bill.cbte_type.should == "06"
+    it "es '' cuando no se informó la condición" do
+      expect(described_class.new(valid_attrs(receiver_iva_condition: nil)).receiver_iva_condition_id).to eq("")
+    end
+  end
+
+  describe "estado del resultado" do
+    it "refleja el veredicto de AFIP" do
+      bill = described_class.new(valid_attrs)
+      bill.result = "A"
+      expect(bill.approved?).to be(true)
+      bill.result = "R"
+      expect(bill.rejected?).to be(true)
+      bill.result = "P"
+      expect(bill.partial_approved?).to be(true)
+    end
+  end
+
+  describe "#valid?" do
+    it "es válido con atributos completos y correctos" do
+      bill = described_class.new(valid_attrs)
+      expect(bill.valid?).to be(true)
+      expect(bill.errors).to be_empty
     end
 
-    it "raise error on nil iva cond" do
-      @bill.iva_cond = 12
-      expect{@bill.cbte_type}.to raise_error(Snoopy::NullOrInvalidAttribute)
+    it "marca currency inválida" do
+      bill = described_class.new(valid_attrs(currency: :yen))
+      expect(bill.valid?).to be(false)
+      expect(bill.errors).to have_key(:currency)
     end
 
-    it "should fetch non Peso currency's exchange rate" do
-      @bill.moneda = :dolar
-      @bill.exchange_rate.to_i.should be > 0
-    end
-
-    it "should return 1 for Peso currency" do
-      @bill.moneda = :peso
-      @bill.exchange_rate.should == 1
-    end
-
-    it "should calculate the IVA array values" do
-      @bill.iva_cond = :responsable_inscripto
-      @bill.moneda = :peso
-      @bill.net = 100.89
-      @bill.aliciva_id = 2
-
-      @bill.iva_sum.should be_within(0.05).of(21.18)
-      @bill.total.should be_within(0.05).of(122.07)
-    end
-
-    it "should use give due date an service dates, or todays date" do
-      @bill.net = 100
-      @bill.aliciva_id = 2
-      @bill.doc_num = "30710151543"
-      @bill.iva_cond = :responsable_inscripto
-      @bill.concepto = "Servicios"
-
-      @bill.setup_bill
-
-      detail = @bill.body["FeCAEReq"]["FeDetReq"]["FECAEDetRequest"]
-
-      detail["FchServDesde"].should == Time.new.strftime('%Y%m%d')
-      detail["FchServHasta"].should == Time.new.strftime('%Y%m%d')
-      detail["FchVtoPago"].should   == Time.new.strftime('%Y%m%d')
-
-      @bill.due_date       = Date.new(2011, 12, 10).strftime('%Y%m%d')
-      @bill.fch_serv_desde = Date.new(2011, 11, 01).strftime('%Y%m%d')
-      @bill.fch_serv_hasta = Date.new(2011, 11, 30).strftime('%Y%m%d')
-
-      @bill.setup_bill
-
-      detail = @bill.body["FeCAEReq"]["FeDetReq"]["FECAEDetRequest"]
-
-      detail["FchServDesde"].should == "20111101"
-      detail["FchServHasta"].should == "20111130"
-      detail["FchVtoPago"].should   == "20111210"
-    end
-
-    Snoopy::BILL_TYPE[Snoopy.own_iva_cond].keys.each do |target_iva_cond|
-      it "should authorize a valid bill for #{target_iva_cond.to_s}" do
-        @bill.net = 1000000
-        @bill.aliciva_id = 2
-        @bill.doc_num = "30710151543"
-        @bill.iva_cond = target_iva_cond
-        @bill.concepto = "Servicios"
-
-        @bill.authorized?.should  == false
-        @bill.authorize.should    == true
-        @bill.authorized?.should  == true
-
-        response = @bill.response
-
-        response.length.should     == 28
-        response.cae.length.should == 14
-      end
+    it "marca document_type inválido" do
+      bill = described_class.new(valid_attrs(document_type: "NOPE"))
+      bill.valid?
+      expect(bill.errors).to have_key(:document_type)
     end
   end
 end

--- a/spec/snoopy_afip/exceptions_spec.rb
+++ b/spec/snoopy_afip/exceptions_spec.rb
@@ -1,0 +1,27 @@
+require File.expand_path(File.dirname(__FILE__) + "/../spec_helper")
+
+RSpec.describe Snoopy::Exception do
+  # Regresión #14: ServerTimeout debe seguir siendo un Timeout::Error (compat
+  # hacia atrás) y a la vez quedar bajo el paraguas Snoopy::Exception::Error.
+  describe "jerarquía de ServerTimeout" do
+    subject(:ancestors) { Snoopy::Exception::ServerTimeout.ancestors }
+
+    it "sigue siendo un Timeout::Error" do
+      expect(ancestors).to include(Timeout::Error)
+    end
+
+    it "queda bajo el paraguas Snoopy::Exception::Error" do
+      expect(ancestors).to include(Snoopy::Exception::Error)
+    end
+  end
+
+  it "el paraguas Error cubre también a las excepciones de la base" do
+    expect(Snoopy::Exception::ClientError.ancestors).to include(Snoopy::Exception::Error)
+    expect(Snoopy::Exception::AuthorizeAdapter::BuildBodyRequest.ancestors).to include(Snoopy::Exception::Error)
+  end
+
+  it "un rescue del paraguas atrapa tanto el timeout como los errores de cliente" do
+    expect { raise Snoopy::Exception::ServerTimeout }.to raise_error(Snoopy::Exception::Error)
+    expect { raise Snoopy::Exception::ClientError.new("x") }.to raise_error(Snoopy::Exception::Error)
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,23 +1,19 @@
-$:.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
-require 'snoopy'
-require 'rspec'
-require 'ruby-debug'
+$LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
 
-class SpecHelper
-  include Savon::Logger
+require "snoopy_afip"
+# Bill#valid? usa blank?/present? (ActiveSupport); en producción lo provee Rails.
+require "active_support/core_ext/object/blank"
+require "rspec"
+
+# Config base de homologación para construir adapters en los specs.
+# Nunca credenciales reales: pkey/cert/cuit son placeholders de prueba.
+Snoopy.auth_url            = "https://wsaahomo.afip.gov.ar/ws/services/LoginCms?wsdl"
+Snoopy.service_url         = "https://wswhomo.afip.gov.ar/wsfev1/service.asmx?WSDL"
+Snoopy.default_currency    = :peso
+Snoopy.default_concept     = "Productos"
+Snoopy.default_document_type = "CUIT"
+
+RSpec.configure do |config|
+  config.expect_with(:rspec) { |e| e.syntax = :expect }
+  config.disable_monkey_patching!
 end
-
-# Requires supporting files with custom matchers and macros, etc,
-# in ./support/ and its subdirectories.
-Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each {|f| require f}
-
-Snoopy.pkey = "spec/fixtures/pkey"
-Snoopy.cert = "spec/fixtures/cert.crt"
-Snoopy.cuit = ENV["CUIT"] || raise(Snoopy::NullOrInvalidAttribute.new, "Please set CUIT env variable.")
-Snoopy.sale_point = "0002"
-Snoopy.auth_url = "https://wsaahomo.afip.gov.ar/ws/services/LoginCms"
-Snoopy.service_url = "http://wswhomo.afip.gov.ar/wsfev1/service.asmx?WSDL"
-Snoopy.default_concepto = "Productos y Servicios"
-Snoopy.default_documento = "CUIT"
-Snoopy.default_moneda = :peso
-Snoopy.own_iva_cond = :responsable_inscripto


### PR DESCRIPTION
Refs #13

## Qué

La suite RSpec estaba muerta (API de la era "Bravo", `require 'snoopy'` roto, `rspec`/`ruby-debug` sin declarar). Reescrita contra la API actual y **verde**: `21 examples, 0 failures` bajo **Ruby 2.7.x** (runtime del consumidor `argentina_invoice_service`).

### Specs nuevos (unit puros, sin fixtures ni red)
| archivo | cubre |
|---|---|
| `bill_spec.rb` | `Bill`: cbte_type, iva_sum/total, exchange_rate, receiver_iva_condition_id, estado, `valid?` |
| `authorize_adapter_spec.rb` | `auth` + **regresión #10/#16** (rescues de parseo no explotan, registran String) |
| `authentication_adapter_spec.rb` | `build_tra`, credenciales de instancia |
| `exceptions_spec.rb` | **regresión #14** (ServerTimeout sigue `Timeout::Error` y bajo el paraguas `Error`) |

### Infra
- **gemspec**: declara `rspec ~> 3.13` + `activesupport` como dev deps (antes `rspec` no estaba en ningún lado). `test_files` por glob.
- **Gemfile**: pin `rack ~> 2.2` (httpi 2.x usa `Rack::Utils::HeaderHash`, removido en rack 3) — entorno de test.
- **Gemfile.lock**: regenerado (estaba clavado en `4.0.1` con `nokogiri 1.10.9`); resuelto para Ruby 2.7 (`nokogiri 1.15.7`).
- **exceptions.rb**: `require "timeout"` explícito (en Ruby 3.4+ `timeout` es default gem no autocargado y `ServerTimeout < Timeout::Error` fallaba al cargar).

## ⚠️ Limitación de runtime (importante)

**La gema no carga en Ruby 3.x.** El stack de savon 2.12 (httpi 2.x) depende de `kconv` (removido de stdlib en 3.x) y `Rack::Utils::HeaderHash` (removido en rack 3). Por eso la suite corre en **Ruby 2.7.x** y el lock está resuelto para 2.7. Modernizar a Ruby 3.x requiere el **upgrade de savon a 2.15+ (httpi 4)** — gated (roadmap en #13). Documentado en `docs/test/testing.md` y `AGENTS.md §6`.

## Qué falta (próximo incremento)
Caminos felices contra AFIP (`authorize!`/`authenticate!`/`set_bill_number!`) — requieren mock de Savon o VCR. Hoy se cubre la lógica pura + el comportamiento de error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)