### PR TITLE
feat!: upgrade savon 2.12 → 2.17 (httpi 4) para Ruby 3.x (#19)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,10 +23,10 @@ El repo consume skills del framework de agentes, declaradas en `skills.yml`. Las
 
 ## 3. Entorno
 
-- Lenguaje: **Ruby**. No hay `.ruby-version` en el repo (no fijar una versión que no esté declarada).
-- Dependencias resueltas en `Gemfile.lock`. Dependencia de runtime principal: `savon ~> 2.12.1` (cliente SOAP), declarada en el `.gemspec`.
+- Lenguaje: **Ruby**, **requiere ≥ 3.0** (`required_ruby_version` en el `.gemspec`; savon 2.17/httpi 4 lo exigen). No hay `.ruby-version` en el repo.
+- Dependencias resueltas en `Gemfile.lock`. Dependencia de runtime principal: `savon ~> 2.17` (cliente SOAP sobre httpi 4 / faraday), declarada en el `.gemspec`.
 - Gestión de versiones de Ruby con **chruby** (no rvm, no rbenv).
-- **Bundler** para dependencias (`BUNDLED WITH 2.1.4` en `Gemfile.lock`). Instalar con `bundle install`.
+- **Bundler** para dependencias. Instalar con `bundle install`.
 
 ## 4. RuboCop
 
@@ -52,7 +52,7 @@ bundle exec rspec
 
 El código nuevo debe venir con tests. La suite (`spec/snoopy_afip/{bill,authorize_adapter,authentication_adapter,exceptions}_spec.rb`) son unit puros, sin fixtures ni llamadas reales a AFIP; usar placeholders, nunca CUIT/credenciales reales.
 
-**Runtime: la suite corre bajo Ruby 2.7.x** (runtime del consumidor). En Ruby 3.x la gema **no carga** — el stack de savon 2.12 (httpi 2.x) depende de `kconv` y `Rack::Utils::HeaderHash`, removidos en Ruby 3.x / rack 3. Correr en 3.x requiere el upgrade de savon a 2.15+ (ver `docs/test/testing.md`). El `Gemfile.lock` está resuelto para 2.7.
+**Runtime: la suite corre bajo Ruby ≥ 3.0.** Tras el upgrade a savon 2.17 (httpi 4, #19) la gema requiere Ruby ≥ 3.0 y dejó de soportar 2.7. El consumidor `argentina_invoice_service` (Ruby 2.7.6) debe subir su Ruby antes de adoptar la versión nueva (ver #19 / `docs/test/testing.md`).
 
 ## 7. Releases
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,6 @@
 source "http://rubygems.org"
 
 gemspec
-
-# httpi 2.x (vía savon 2.12) usa Rack::Utils::HeaderHash, removido en rack 3.
-# Pin de entorno de test; el consumidor Rails trae su propio rack 2.x.
-gem "rack", "~> 2.2"
 # group :development do
 #   platforms :ruby_18 do
 #     gem "ruby-debug"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,54 +2,101 @@ PATH
   remote: .
   specs:
     snoopy_afip (4.3.0)
-      savon (~> 2.12.1)
+      savon (~> 2.17)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    activesupport (7.1.6)
+    activesupport (8.1.3)
       base64
-      benchmark (>= 0.3)
       bigdecimal
-      concurrent-ruby (~> 1.0, >= 1.0.2)
+      concurrent-ruby (~> 1.0, >= 1.3.1)
       connection_pool (>= 2.2.5)
       drb
       i18n (>= 1.6, < 2)
+      json
       logger (>= 1.4.2)
       minitest (>= 5.1)
-      mutex_m
       securerandom (>= 0.3)
-      tzinfo (~> 2.0)
+      tzinfo (~> 2.0, >= 2.0.5)
+      uri (>= 0.13.1)
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
-    akami (1.3.2)
+    akami (1.3.3)
+      base64
       gyoku (>= 0.4.0)
       nokogiri
     base64 (0.3.0)
-    benchmark (0.5.0)
     bigdecimal (4.1.2)
     builder (3.3.0)
     concurrent-ruby (1.3.7)
-    connection_pool (2.5.5)
+    connection_pool (3.0.2)
+    date (3.5.1)
     diff-lcs (1.6.2)
     drb (2.2.3)
+    faraday (2.14.3)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-net_http (3.4.4)
+      net-http (~> 0.5)
     gyoku (1.4.0)
       builder (>= 2.1.2)
       rexml (~> 3.0)
-    httpi (2.5.0)
-      rack
-      socksify
-    i18n (1.14.8)
+    httpi (4.0.4)
+      base64
+      mutex_m
+      nkf
+      rack (>= 2.0, < 4)
+    i18n (1.15.2)
       concurrent-ruby (~> 1.0)
+    json (2.20.0)
     logger (1.7.0)
-    minitest (5.26.1)
+    mail (2.9.0)
+      logger
+      mini_mime (>= 0.1.1)
+      net-imap
+      net-pop
+      net-smtp
+    mini_mime (1.1.5)
+    minitest (6.0.6)
+      drb (~> 2.0)
+      prism (~> 1.5)
     mutex_m (0.3.0)
-    nokogiri (1.15.7-arm64-darwin)
+    net-http (0.9.1)
+      uri (>= 0.11.1)
+    net-imap (0.6.4.1)
+      date
+      net-protocol
+    net-pop (0.1.2)
+      net-protocol
+    net-protocol (0.2.2)
+      timeout
+    net-smtp (0.5.1)
+      net-protocol
+    nkf (0.3.0)
+    nokogiri (1.19.4-aarch64-linux-gnu)
       racc (~> 1.4)
-    nori (2.6.0)
-    public_suffix (5.1.1)
+    nokogiri (1.19.4-aarch64-linux-musl)
+      racc (~> 1.4)
+    nokogiri (1.19.4-arm-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.19.4-arm-linux-musl)
+      racc (~> 1.4)
+    nokogiri (1.19.4-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.19.4-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.19.4-x86_64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.19.4-x86_64-linux-musl)
+      racc (~> 1.4)
+    nori (2.7.1)
+      bigdecimal
+    prism (1.9.0)
+    public_suffix (7.0.5)
     racc (1.8.1)
-    rack (2.2.23)
+    rack (3.2.6)
     rexml (3.4.4)
     rspec (3.13.2)
       rspec-core (~> 3.13.0)
@@ -64,31 +111,95 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.7)
-    savon (2.12.1)
+    savon (2.17.3)
       akami (~> 1.2)
       builder (>= 2.1.2)
       gyoku (~> 1.2)
-      httpi (~> 2.3)
+      httpi (>= 4, < 5)
+      mail (~> 2.5)
       nokogiri (>= 1.8.1)
-      nori (~> 2.4)
-      wasabi (~> 3.4)
-    securerandom (0.3.2)
-    socksify (1.8.1)
+      nori (~> 2.7)
+      wasabi (>= 5.1.0, < 6)
+    securerandom (0.4.1)
+    timeout (0.6.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    wasabi (3.7.0)
+    uri (1.1.1)
+    wasabi (5.1.0)
       addressable
-      httpi (~> 2.0)
-      nokogiri (>= 1.4.2)
+      faraday (>= 1.9, < 3)
+      nokogiri (>= 1.13.9)
 
 PLATFORMS
-  arm64-darwin-24
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux-gnu
+  arm-linux-musl
+  arm64-darwin
+  x86_64-darwin
+  x86_64-linux-gnu
+  x86_64-linux-musl
 
 DEPENDENCIES
   activesupport
-  rack (~> 2.2)
   rspec (~> 3.13)
   snoopy_afip!
 
+CHECKSUMS
+  activesupport (8.1.3) sha256=21a5e0dfbd4c3ddd9e1317ec6a4d782fa226e7867dc70b0743acda81a1dca20e
+  addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
+  akami (1.3.3) sha256=d661b97abac1f771381cfb88fc62cf42cd72488c96d750988f4643cd7064b6bf
+  base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
+  bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
+  builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
+  concurrent-ruby (1.3.7) sha256=4412caec3a5ea2e5fdc52076724c071a81f2c0593d83b2ac8cbb8ca63b3151b0
+  connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
+  date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
+  diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
+  drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
+  faraday (2.14.3) sha256=1882247e6766615c8220b4392bf1d27f6ebb63d8e28267587cef1fb0bf37f278
+  faraday-net_http (3.4.4) sha256=0e78af151747ed1b00f33e25973b4bc220d7f16c00c39676817c8b12331eb588
+  gyoku (1.4.0) sha256=389d887384c777f271cb9377bb642f20bbe0c633d1ef5af78569d4db53c1a2cd
+  httpi (4.0.4) sha256=ca629bb9492a733dad1c6aabecc6f70e0847b10f4fe6eeb82ac120513455a23e
+  i18n (1.15.2) sha256=00f9eb62412fe593b2a65a97daa75300d37abb8f7202ec748e94b6d46a9dd1b5
+  json (2.20.0) sha256=9362bc6e55a952b056abf9167cf053358181c904cb70cd6eee0808ea830fc32b
+  logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
+  mail (2.9.0) sha256=6fa6673ecd71c60c2d996260f9ee3dd387d4673b8169b502134659ece6d34941
+  mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
+  minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1
+  mutex_m (0.3.0) sha256=cfcb04ac16b69c4813777022fdceda24e9f798e48092a2b817eb4c0a782b0751
+  net-http (0.9.1) sha256=25ba0b67c63e89df626ed8fac771d0ad24ad151a858af2cc8e6a716ca4336996
+  net-imap (0.6.4.1) sha256=29f0360d75a7efd3539f16ac1957dea5c0a51ddeceb348db4553c3120914ea0d
+  net-pop (0.1.2) sha256=848b4e982013c15b2f0382792268763b748cce91c9e91e36b0f27ed26420dff3
+  net-protocol (0.2.2) sha256=aa73e0cba6a125369de9837b8d8ef82a61849360eba0521900e2c3713aa162a8
+  net-smtp (0.5.1) sha256=ed96a0af63c524fceb4b29b0d352195c30d82dd916a42f03c62a3a70e5b70736
+  nkf (0.3.0) sha256=357a8dbeba38b727b75930f665146546076a394a1c243faf634ff176e3588895
+  nokogiri (1.19.4-aarch64-linux-gnu) sha256=1269fb644a6de405057a53dd5c762b1209b43ca7424f839454d3dbc677c31a8f
+  nokogiri (1.19.4-aarch64-linux-musl) sha256=35c65b9ce72b3bb03207bdbe7067915019dc18c1b9b59139684bd6690fdd01af
+  nokogiri (1.19.4-arm-linux-gnu) sha256=a301313e38bb065d68239e79734bcd6f56fb6efaacebde29e9abf2a4735340ca
+  nokogiri (1.19.4-arm-linux-musl) sha256=588923c101bcfa78869734d247d25b598674323e7f22474fc468f6e5647311eb
+  nokogiri (1.19.4-arm64-darwin) sha256=a46db9853286e6597b36ebc6953817d15acf3a299583eb3f89fdc6f91dd63527
+  nokogiri (1.19.4-x86_64-darwin) sha256=7fd17057d3e1f00e9954a74b3cd76595d3d4a5ef233b7ed9599047c204f70551
+  nokogiri (1.19.4-x86_64-linux-gnu) sha256=379fae440b28915e3f19d752ce2dcf8465ed2b2fbefd2a7ca0dd497bc981a06a
+  nokogiri (1.19.4-x86_64-linux-musl) sha256=17dfb7c1fa194ae02fbf7c51a7afc8d278045ab3fdacfd86f91d02d7b274470b
+  nori (2.7.1) sha256=6166cd336959854762073e2fbae888593809cac1b3e904f4fb009313d7226861
+  prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
+  public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
+  racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
+  rack (3.2.6) sha256=5ed78e1f73b2e25679bec7d45ee2d4483cc4146eb1be0264fc4d94cb5ef212c2
+  rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
+  rspec (3.13.2) sha256=206284a08ad798e61f86d7ca3e376718d52c0bc944626b2349266f239f820587
+  rspec-core (3.13.6) sha256=a8823c6411667b60a8bca135364351dda34cd55e44ff94c4be4633b37d828b2d
+  rspec-expectations (3.13.5) sha256=33a4d3a1d95060aea4c94e9f237030a8f9eae5615e9bd85718fe3a09e4b58836
+  rspec-mocks (3.13.8) sha256=086ad3d3d17533f4237643de0b5c42f04b66348c28bf6b9c2d3f4a3b01af1d47
+  rspec-support (3.13.7) sha256=0640e5570872aafefd79867901deeeeb40b0c9875a36b983d85f54fb7381c47c
+  savon (2.17.3) sha256=db9da98e222d7e22c4c7f3da967b35ca44d3f6c134574503d2247c1bdded60c6
+  securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
+  snoopy_afip (4.3.0)
+  timeout (0.6.1) sha256=78f57368a7e7bbadec56971f78a3f5ecbcfb59b7fcbb0a3ed6ddc08a5094accb
+  tzinfo (2.0.6) sha256=8daf828cc77bcf7d63b0e3bdb6caa47e2272dcfaf4fbfe46f8c3a9df087a829b
+  uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
+  wasabi (5.1.0) sha256=e2d8252fbecb03b116b6085c683878bfad23b867654977b778c1d8c6621b84cc
+
 BUNDLED WITH
-   2.4.22
+  4.0.9

--- a/docs/test/testing.md
+++ b/docs/test/testing.md
@@ -3,7 +3,7 @@
 
 ## 1. Resumen
 
-Suite RSpec en `spec/`, **reescrita contra la API actual y verde** (`21 examples, 0 failures`). Corre bajo **Ruby 2.7.x** (runtime del consumidor `argentina_invoice_service`). En **Ruby 3.x la gema no carga**: el stack de savon 2.12 (httpi 2.x) depende de `kconv` (removido de stdlib en 3.x) y de `Rack::Utils::HeaderHash` (removido en rack 3) → correr en 3.x requiere el upgrade de savon (gated, ver #13/roadmap).
+Suite RSpec en `spec/`, **reescrita contra la API actual y verde** (`21 examples, 0 failures`) bajo **Ruby 3.x**. Tras el upgrade a savon 2.17 (httpi 4, #19) la gema **requiere Ruby ≥ 3.0** (savon 2.15+/httpi 4 lo exigen) y dejó de soportar Ruby 2.7.
 
 ## 2.a Suites, frameworks y niveles
 
@@ -18,10 +18,10 @@ Suite RSpec en `spec/`, **reescrita contra la API actual y verde** (`21 examples
 ## 2.b Comando de corrida
 
 ```bash
-bundle exec rspec    # bajo Ruby 2.7.x
+bundle exec rspec    # bajo Ruby >= 3.0
 ```
 
-No hay CI declarado (sin `.github/workflows/`, `.circleci/`, `bin/ci`, `config/ci.rb`). Corrida solo local. Dev-deps de test: `rspec ~> 3.13`, `activesupport` (gemspec); pin `rack ~> 2.2` (Gemfile, requerido por httpi 2.x).
+No hay CI declarado (sin `.github/workflows/`, `.circleci/`, `bin/ci`, `config/ci.rb`). Corrida solo local. Dev-deps de test: `rspec ~> 3.13`, `activesupport` (gemspec).
 
 ## 2.c Fixtures / Factories
 
@@ -64,8 +64,8 @@ Ninguna (sin `.simplecov` / `SimpleCov.start`). Sin umbral declarado.
 
 | ítem | confidence | a verificar |
 |---|---|---|
-| La gema no carga en Ruby 3.x (kconv/httpi 2.x, Rack::Utils::HeaderHash/rack 3) | declared | desbloquea con el upgrade de savon a 2.15+ (httpi 4) — gated |
-| El lock está resuelto para Ruby 2.7 (nokogiri 1.15.7, rack 2.2) | declared | un dev en Ruby 3.x no podrá `bundle install` hasta el upgrade |
+| La gema requiere Ruby ≥ 3.0 tras el upgrade a savon 2.17 (#19); ya no soporta 2.7 | declared | el consumidor `argentina_invoice_service` (Ruby 2.7.6) debe subir Ruby antes de adoptar la versión nueva |
+| El handshake mTLS contra AFIP con httpi 4 NO se validó en tests (solo el build del cliente) | declared | validar WSAA+WSFE contra homologación con certs reales; revisar `SNOOPY_SSL_VERSION` (default `:TLSv1` desactualizado) |
 
 ## 4. Cobertura y fronteras
 

--- a/docs/topology/topology.md
+++ b/docs/topology/topology.md
@@ -9,11 +9,13 @@ Gema cliente SOAP. Una sola dependencia de runtime declarada en el `.gemspec` (`
 
 | nombre | versión | rol |
 |---|---|---|
-| `savon` | `~> 2.12.1` (gemspec) · `2.12.0` (lock) | cliente SOAP — única dep de runtime declarada |
-| `httpi` | `2.4.4` (lock, transitiva) | capa HTTP de savon |
-| `nori` | `2.6.0` (lock, transitiva) | XML→Hash (usado directo en `AuthenticationAdapter`) |
-| `nokogiri` | `1.10.9` (lock, transitiva) | parser XML; usado directo en `build_tra` (`Nokogiri::XML::Builder`) |
-| `gyoku` `akami` `wasabi` `builder` `rack` `socksify` `mini_portile2` | ver lock | transitivas de savon |
+| `savon` | `~> 2.17` (gemspec) · `2.17.3` (lock) | cliente SOAP — única dep de runtime declarada |
+| `httpi` | `4.0.4` (lock, transitiva) | capa HTTP de savon (sobre `faraday`) |
+| `faraday` | `2.14.3` (lock, transitiva) | backend HTTP de httpi 4 |
+| `nori` | `2.7.x` (lock, transitiva) | XML→Hash (usado directo en `AuthenticationAdapter`) |
+| `nokogiri` | `1.19.4` (lock, transitiva) | parser XML; usado directo en `build_tra` (`Nokogiri::XML::Builder`) |
+| `nkf` | `0.3.0` (lock, transitiva) | encoding en httpi 4 (reemplazo del `kconv` removido de stdlib) |
+| `gyoku` `akami` `wasabi` `builder` | ver lock | transitivas de savon |
 | `OpenSSL` (stdlib) | — | firma CMS/PKCS7, generación de clave/CSR |
 | `Timeout` (stdlib) | — | corta llamadas SOAP (`Snoopy::Client#call`) |
 
@@ -39,6 +41,6 @@ flowchart LR
 
 ## 5. Cobertura y fronteras
 
-- **`Gemfile.lock` divergente** (ver `docs/test/` y nota global): el lock fija `snoopy_afip (4.0.1)` mientras `version.rb` dice `4.3.0`, y lista en `PATH specs` deps (`akami`, `nokogiri`, `nori`, `wasabi`) que el `.gemspec` **actual** no declara explícitamente (solo `savon`). El lock parece no regenerado tras cambios de gemspec/versión. Versiones de la tabla tomadas del lock como mejor evidencia disponible, marcadas.
+- **`Gemfile.lock` regenerado** con el stack httpi 4 (savon 2.17). **Requiere Ruby ≥ 3.0** (savon 2.15+/httpi 4/wasabi 5 exigen 3.0). El lock se resuelve para Ruby 3.x.
 - Servicios AFIP externos (WSAA/WSFE): contrato consumido en `docs/consumed/` (RFC-018).
 - Topología upstream de AFIP (infra del organismo) fuera de alcance.

--- a/snoopy_afip.gemspec
+++ b/snoopy_afip.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.name = "snoopy_afip"
   s.version = Snoopy::VERSION
 
-  s.required_ruby_version = ">= 2.5"
+  s.required_ruby_version = ">= 3.0"
   s.authors = ["g.edera"]
   s.description = "Adaptador para Web Service de Facturación Electrónica Argentina (AFIP)"
   s.email = "gab.edera@gmail.com"
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.summary = "Adaptador AFIP wsfe."
   s.test_files = Dir["spec/**/*"]
 
-  s.add_dependency 'savon', '~> 2.12.1'
+  s.add_dependency 'savon', '~> 2.17'
 
   s.add_development_dependency 'rspec', '~> 3.13'
   s.add_development_dependency 'activesupport' # Bill#valid? usa blank?/present?


### PR DESCRIPTION
Refs #19

## ⚠️ BREAKING CHANGE — requiere Ruby >= 3.0

La gema deja de soportar Ruby 2.7. **El consumidor `argentina_invoice_service` corre Ruby 2.7.6 → no podrá instalar esta versión hasta subir su Ruby a 3.0+.** Coordinar antes de release.

## Qué

| | antes | después |
|---|---|---|
| savon | `~> 2.12.1` | `~> 2.17` (2.17.3) |
| httpi | 2.x (kconv, rack 2) | 4.0.4 (faraday, sin kconv) |
| wasabi | 3.x | 5.1.0 |
| nokogiri | 1.10.9 | 1.19.4 |
| required_ruby_version | `>= 2.5` | `>= 3.0` |

savon 2.12/httpi 2.x **no carga en Ruby 3.x** (`kconv` fuera de stdlib, `Rack::Utils::HeaderHash` fuera de rack 3). savon 2.15+ usa httpi 4 (sin kconv) pero **exige Ruby >= 3.0** — no existe savon que soporte 2.7 y 3.x simultáneamente, así que el upgrade implica dropear 2.7.

- Gemfile: quitado el pin `rack ~> 2.2` (era para httpi 2).
- Gemfile.lock regenerado bajo Ruby 3.4.

## Validado ✅
- Carga en Ruby 3.4.
- Suite RSpec verde: **21 examples, 0 failures** en Ruby 3.4.
- savon 2.17 sigue aceptando las opciones SSL de `client_configuration` (`ssl_cert_file`/`ssl_cert_key_file`/`ssl_version`/`headers`/`namespaces`/timeouts): el build del cliente Savon no levanta `Savon::UnknownOptionError`.

## NO validado ❌ (bloquea release)
1. **Handshake mTLS real contra homologación AFIP** (WSAA + WSFE) — requiere certs reales; httpi 4 usa faraday-net_http, distinto adapter que httpi 2.
2. **`SNOOPY_SSL_VERSION` default `:TLSv1`** — desactualizado; AFIP exige TLS ≥ 1.2. Verificar/override en la validación.

## Antes de mergear/release
- [ ] Validar WSAA + WSFE contra homologación AFIP con certs de prueba.
- [ ] Confirmar/ajustar `SNOOPY_SSL_VERSION`.
- [ ] Coordinar upgrade de Ruby del consumidor (2.7.6 → 3.0+).
- [ ] Bump SemVer **mayor** (breaking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)