### PR TITLE
ci: CI + release automatizado a RubyGems (modelo bug_bunny)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,31 @@
+name: Ruby
+
+on:
+  push:
+    branches:
+      - master
+
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    name: Ruby ${{ matrix.ruby }}
+    strategy:
+      matrix:
+        ruby:
+          # La gema en master corre sobre el stack savon 2.12 (httpi 2.x), que
+          # requiere Ruby 2.7. Al mergear el upgrade a savon 2.17 (#19), subir a 3.x.
+          - '2.7'
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - name: Run specs
+        run: bundle exec rspec

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+name: Publish to RubyGems
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    name: Build + Publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - uses: actions/checkout@v5
+
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '3.2'
+
+    - name: Publish to RubyGems
+      run: |
+        mkdir -p $HOME/.gem
+        touch $HOME/.gem/credentials
+        chmod 0600 $HOME/.gem/credentials
+        printf -- "---\n:rubygems_api_key: ${RUBYGEMS_API_KEY}\n" > $HOME/.gem/credentials
+        gem build *.gemspec
+        gem push *.gem
+      env:
+        RUBYGEMS_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,9 +56,11 @@ El código nuevo debe venir con tests. La suite (`spec/snoopy_afip/{bill,authori
 
 ## 7. Releases
 
-Usar la skill `/gem-release` (declarada en `skills.yml`) para publicar versiones. La versión vive en `lib/snoopy_afip/version.rb` (`Snoopy::VERSION`).
+La versión vive en `lib/snoopy_afip/version.rb` (`Snoopy::VERSION`).
 
-No hay GitHub Action de release en el repo (no existe `.github/workflows/`). No documentar un pipeline automático que no esté presente.
+**Release automatizado por GitHub Actions** (`.github/workflows/release.yml`): publicar = bump de `version.rb` + commit + `git tag vX.Y.Z` + push del tag → el workflow corre `gem build` + `gem push` a RubyGems. Requiere el secret `RUBYGEMS_API_KEY` en el repo. No hace falta `gem push` manual.
+
+**CI** (`.github/workflows/main.yml`): corre `bundle exec rspec` en cada push a master y PR. Hoy en **Ruby 2.7** (stack savon 2.12); subir a 3.x al mergear el upgrade de savon (#19).
 
 ## 8. Arquitectura
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,8 @@ GEM
     mutex_m (0.3.0)
     nokogiri (1.15.7-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.15.7-x86_64-linux)
+      racc (~> 1.4)
     nori (2.6.0)
     public_suffix (5.1.1)
     racc (1.8.1)
@@ -83,6 +85,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-24
+  x86_64-linux
 
 DEPENDENCIES
   activesupport


### PR DESCRIPTION
Replica el modelo de workflows de `bug_bunny`, adaptado a la realidad de esta gema.

## Workflows

- **`main.yml`** (CI): corre `bundle exec rspec` en push a master y en PRs.
- **`release.yml`** (publish): en push de tag `v*` → `gem build` + `gem push` a RubyGems.

## Adaptaciones vs bug_bunny (necesarias)

| | bug_bunny | acá | por qué |
|---|---|---|---|
| CI Ruby | 3.4.4 | **2.7** | master usa savon 2.12/httpi 2.x → no carga en 3.x (kconv). Subir a 3.x al mergear #19/#20 |
| comando CI | `bundle exec rake` | `bundle exec rspec` | el Rakefile hace `require 'jeweler'` (gema muerta) → `rake` explota |
| plataformas lock | tenía `ruby` | **+`x86_64-linux`** | el lock solo tenía `arm64-darwin` → CI en ubuntu fallaba; ahora trae nokogiri precompilado para linux |

`release.yml` es prácticamente idéntico (`gem build` no carga savon, corre en cualquier Ruby).

## ⚠️ Acción requerida (manual, no la puede hacer el agente)

Agregar el secret **`RUBYGEMS_API_KEY`** en `Settings → Secrets and variables → Actions` del repo, con la API key de RubyGems. Sin eso, `release.yml` falla el `gem push`.

## Nuevo flujo de release

```
bump version.rb → commit → git tag vX.Y.Z → git push --tags  → GHA publica
```

Reemplaza el `gem push` manual. (También actualiza `AGENTS.md §7`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)